### PR TITLE
feat: [#4] 태그 등록 기능 구현

### DIFF
--- a/src/main/java/weavers/siltarae/global/exception/ExceptionCode.java
+++ b/src/main/java/weavers/siltarae/global/exception/ExceptionCode.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ExceptionCode {
     INVALID_REQUEST(1000, "올바르지 않은 요청입니다."),
+    DUPLICATED_TAG_NAME(1001, "중복된 태그명입니다."),
 
     INVALID_MISTAKE_CONTENT_SIZE(2001, "실수 내용은 140자가 넘을 수 없습니다."),
     INVALID_MISTAKE_CONTENT_NULL(2002, "실수 내용은 필수입니다."),

--- a/src/main/java/weavers/siltarae/global/exception/ExceptionCode.java
+++ b/src/main/java/weavers/siltarae/global/exception/ExceptionCode.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ExceptionCode {
     INVALID_REQUEST(1000, "올바르지 않은 요청입니다."),
-    DUPLICATED_TAG_NAME(1001, "중복된 태그명입니다."),
+    DUPLICATED_TAG_NAME(3001, "중복된 태그명입니다."),
 
     INVALID_MISTAKE_CONTENT_SIZE(2001, "실수 내용은 140자가 넘을 수 없습니다."),
     INVALID_MISTAKE_CONTENT_NULL(2002, "실수 내용은 필수입니다."),

--- a/src/main/java/weavers/siltarae/tag/controller/TagController.java
+++ b/src/main/java/weavers/siltarae/tag/controller/TagController.java
@@ -1,0 +1,27 @@
+package weavers.siltarae.tag.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import weavers.siltarae.tag.dto.request.TagCreateRequest;
+import weavers.siltarae.tag.service.TagService;
+
+@RestController
+@RequestMapping("/api/v1/category")
+@RequiredArgsConstructor
+public class TagController {
+
+    private final Long TEMP_USER_ID = 1L;
+
+    private final TagService tagService;
+
+    @PostMapping
+    public ResponseEntity<Void> createTag(@RequestBody @Valid final TagCreateRequest request) {
+        tagService.save(TEMP_USER_ID, request);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/weavers/siltarae/tag/domain/repository/TagRepository.java
+++ b/src/main/java/weavers/siltarae/tag/domain/repository/TagRepository.java
@@ -4,4 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import weavers.siltarae.tag.domain.Tag;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
+    boolean existsByUser_UserIdAndName(Long userId, String name);
 }

--- a/src/main/java/weavers/siltarae/tag/dto/request/TagCreateRequest.java
+++ b/src/main/java/weavers/siltarae/tag/dto/request/TagCreateRequest.java
@@ -1,0 +1,26 @@
+package weavers.siltarae.tag.dto.request;
+
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TagCreateRequest {
+
+    @NotEmpty(message = "태그명을 입력해주세요.")
+    @Length(max = 10, message = "태그명은 최대 10자입니다.")
+    @Pattern(regexp = "^[0-9a-zA-Zㄱ-ㅎ가-힣_]*$", message = "태그명에는 한글, 영어, 숫자, _만 사용 가능합니다.")
+    private String name;
+
+    @Builder
+    public TagCreateRequest(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/weavers/siltarae/tag/service/TagService.java
+++ b/src/main/java/weavers/siltarae/tag/service/TagService.java
@@ -1,0 +1,49 @@
+package weavers.siltarae.tag.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import weavers.siltarae.global.exception.BadRequestException;
+import weavers.siltarae.global.exception.ExceptionCode;
+import weavers.siltarae.tag.domain.repository.TagRepository;
+import weavers.siltarae.tag.domain.Tag;
+import weavers.siltarae.tag.dto.request.TagCreateRequest;
+import weavers.siltarae.user.domain.User;
+import weavers.siltarae.user.domain.repository.UserRepository;
+
+import java.time.LocalDateTime;
+
+import static weavers.siltarae.global.exception.ExceptionCode.*;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TagService {
+
+    private final TagRepository tagRepository;
+
+    private final UserRepository userRepository;
+
+    public Long save(final Long userId, final TagCreateRequest tagCreateRequest) {
+        final User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BadRequestException(INVALID_REQUEST));
+
+        if (checkDuplicateTagName(user.getId(), tagCreateRequest.getName())) {
+            throw new BadRequestException(DUPLICATED_TAG_NAME);
+        }
+
+        final Tag createdTag = Tag.builder()
+                .name(tagCreateRequest.getName())
+                .user(user)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        Tag tag = tagRepository.save(createdTag);
+
+        return tag.getId();
+    }
+
+    private boolean checkDuplicateTagName(final Long userId, final String tagName) {
+        return tagRepository.existsByUser_UserIdAndName(userId, tagName);
+    }
+}

--- a/src/test/java/weavers/siltarae/tag/TagTestFixture.java
+++ b/src/test/java/weavers/siltarae/tag/TagTestFixture.java
@@ -1,0 +1,16 @@
+package weavers.siltarae.tag;
+
+import weavers.siltarae.tag.domain.Tag;
+
+import java.time.LocalDateTime;
+
+public class TagTestFixture {
+
+    public static Tag COMPANY_TAG() {
+        return Tag.builder()
+                .id(1L)
+                .name("회사")
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/test/java/weavers/siltarae/tag/controller/TagControllerTest.java
+++ b/src/test/java/weavers/siltarae/tag/controller/TagControllerTest.java
@@ -1,0 +1,73 @@
+package weavers.siltarae.tag.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import weavers.siltarae.tag.dto.request.TagCreateRequest;
+import weavers.siltarae.tag.service.TagService;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(TagController.class)
+class TagControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private TagService tagService;
+
+    @Test
+    void 태그_등록_요청을_성공한다() throws Exception {
+        // given
+        final TagCreateRequest tagCreateRequest = new TagCreateRequest("tag_Name");
+        
+
+        // when
+        final ResultActions resultActions = mockMvc.perform(post("/api/v1/category")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(tagCreateRequest)));
+
+        // then
+        resultActions.andExpect(status().isNoContent());
+    }
+
+    @Test
+    void 태그명_10자_초과_시_예외가_발생한다() throws Exception {
+        // given
+        final TagCreateRequest tagCreateRequest = new TagCreateRequest("VeryLongTagName");
+
+        // when
+        final ResultActions resultActions = mockMvc.perform(post("/api/v1/category")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(tagCreateRequest)));
+
+        // then
+        resultActions.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("태그명은 최대 10자입니다."));
+    }
+
+    @Test
+    void 태그명에_특수문자가_있으면_예외가_발생한다() throws Exception {
+        // given
+        final TagCreateRequest tagCreateRequest = new TagCreateRequest("Tag$name");
+
+        // when
+        final ResultActions resultActions = mockMvc.perform(post("/api/v1/category")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(tagCreateRequest)));
+
+        // then
+        resultActions.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("태그명에는 한글, 영어, 숫자, _만 사용 가능합니다."));
+    }
+}

--- a/src/test/java/weavers/siltarae/tag/service/TagServiceTest.java
+++ b/src/test/java/weavers/siltarae/tag/service/TagServiceTest.java
@@ -1,0 +1,67 @@
+package weavers.siltarae.tag.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import weavers.siltarae.global.exception.BadRequestException;
+import weavers.siltarae.tag.domain.repository.TagRepository;
+import weavers.siltarae.tag.domain.Tag;
+import weavers.siltarae.tag.dto.request.TagCreateRequest;
+import weavers.siltarae.user.domain.repository.UserRepository;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+import static weavers.siltarae.tag.TagTestFixture.COMPANY_TAG;
+import static weavers.siltarae.user.UserTestFixture.USER_KIM;
+
+@ExtendWith(MockitoExtension.class)
+class TagServiceTest {
+
+    @InjectMocks
+    private TagService tagService;
+
+    @Mock
+    private TagRepository tagRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Test
+    void 태그_생성_후_tagId를_반환한다() {
+        // given
+        final TagCreateRequest tagCreateRequest = new TagCreateRequest("tagName");
+        given(userRepository.findById(anyLong()))
+                .willReturn(Optional.ofNullable(USER_KIM()));
+        given(tagRepository.save(any(Tag.class)))
+                .willReturn(COMPANY_TAG());
+
+        // when
+        final Long actualId = tagService.save(1L, tagCreateRequest);
+
+        // then
+        assertThat(actualId).isEqualTo(1L);
+    }
+
+    @Test
+    void 태그명_중복_시_예외가_발생한다() {
+        // given
+        TagCreateRequest request = new TagCreateRequest("회사");
+        given(userRepository.findById(anyLong()))
+                .willReturn(Optional.ofNullable(USER_KIM()));
+        given(tagRepository.existsByUser_UserIdAndName(1L, "회사"))
+                .willReturn(true);
+
+        // when
+        BadRequestException e = assertThrows(BadRequestException.class,
+                () -> tagService.save(1L, request));
+
+        // then
+        assertThat(e.getMessage()).isEqualTo("중복된 태그명입니다.");
+    }
+}

--- a/src/test/java/weavers/siltarae/user/UserTestFixture.java
+++ b/src/test/java/weavers/siltarae/user/UserTestFixture.java
@@ -1,0 +1,19 @@
+package weavers.siltarae.user;
+
+import weavers.siltarae.user.domain.SocialType;
+import weavers.siltarae.user.domain.User;
+
+import java.time.LocalDateTime;
+
+public class UserTestFixture {
+
+    public static User USER_KIM() {
+        return User.builder()
+                .id(1L)
+                .email("siltarae@nn.com")
+                .createdAt(LocalDateTime.now())
+                .nickname("Kim")
+                .socialType(SocialType.GOOGLE)
+                .build();
+    }
+}


### PR DESCRIPTION
## 🔥 관련 이슈
close #4 

## ✨ 변경사항
- 태그 등록 API를 구현했습니다.
- 태그 등록 테스트를 구현했습니다.
관련해서 `DUPLICATED_TAG_NAME` 이라는 예외 코드를 추가하였습니다.

## 📝 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?

## 추가 설명
- 회원 기능이 아직 구현되지 않아, 임의로 id=1인 유저를 이용하였습니다.
- 테스트에 필요한 데이터를 Fixture로 분리하였습니다.
- 태그명에 공백을 허용할지에 대해 논의가 필요해 보입니다. 현재는 한글, 영어, 숫자, 그리고 언더바만 허용합니다.