### PR TITLE
feat: [#3] 실수 조회, 삭제 기능 구현

### DIFF
--- a/src/main/java/weavers/siltarae/global/exception/ExceptionCode.java
+++ b/src/main/java/weavers/siltarae/global/exception/ExceptionCode.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ExceptionCode {
     INVALID_REQUEST(1000, "올바르지 않은 요청입니다."),
+    DUPLICATED_TAG_NAME(1001, "중복된 태그명입니다."),
 
     INVALID_MISTAKE_CONTENT_SIZE(2001, "실수 내용은 140자가 넘을 수 없습니다."),
     INVALID_MISTAKE_CONTENT_NULL(2002, "실수 내용은 필수입니다."),

--- a/src/main/java/weavers/siltarae/global/exception/ExceptionCode.java
+++ b/src/main/java/weavers/siltarae/global/exception/ExceptionCode.java
@@ -14,7 +14,7 @@ public enum ExceptionCode {
     INVALID_MISTAKE_CONTENT(2003, "실수 내용에는 한글, 영어, 숫자만 허용됩니다."),
     NOT_FOUND_MISTAKE(2004, "해당하는 실수가 존재하지 않습니다."),
 
-    NOT_FOUND_USER(3001, "해당하는 유저가 존재하지 않습니다."),
+    NOT_FOUND_USER(4001, "해당하는 유저가 존재하지 않습니다."),
 
     INTERNAL_SEVER_ERROR(9999, "서버 에러가 발생하였습니다. 관리자에게 문의해 주세요.");
 

--- a/src/main/java/weavers/siltarae/global/exception/ExceptionCode.java
+++ b/src/main/java/weavers/siltarae/global/exception/ExceptionCode.java
@@ -11,6 +11,9 @@ public enum ExceptionCode {
     INVALID_MISTAKE_CONTENT_SIZE(2001, "실수 내용은 140자가 넘을 수 없습니다."),
     INVALID_MISTAKE_CONTENT_NULL(2002, "실수 내용은 필수입니다."),
     INVALID_MISTAKE_CONTENT(2003, "실수 내용에는 한글, 영어, 숫자만 허용됩니다."),
+    NOT_FOUND_MISTAKE(2004, "해당하는 실수가 존재하지 않습니다."),
+
+    NOT_FOUND_USER(3001, "해당하는 유저가 존재하지 않습니다."),
 
     INTERNAL_SEVER_ERROR(9999, "서버 에러가 발생하였습니다. 관리자에게 문의해 주세요.");
 

--- a/src/main/java/weavers/siltarae/global/exception/ExceptionCode.java
+++ b/src/main/java/weavers/siltarae/global/exception/ExceptionCode.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ExceptionCode {
     INVALID_REQUEST(1000, "올바르지 않은 요청입니다."),
-    DUPLICATED_TAG_NAME(1001, "중복된 태그명입니다."),
+    DUPLICATED_TAG_NAME(3001, "중복된 태그명입니다."),
 
     INVALID_MISTAKE_CONTENT_SIZE(2001, "실수 내용은 140자가 넘을 수 없습니다."),
     INVALID_MISTAKE_CONTENT_NULL(2002, "실수 내용은 필수입니다."),

--- a/src/main/java/weavers/siltarae/mistake/controller/MistakeController.java
+++ b/src/main/java/weavers/siltarae/mistake/controller/MistakeController.java
@@ -24,7 +24,7 @@ public class MistakeController {
     private static final Long TEST_USER_ID = 1L;
 
     @PostMapping("")
-    public ResponseEntity<?> createMistake(
+    public ResponseEntity<Void> createMistake(
             @RequestBody @Valid MistakeCreateRequest request) {
         Long mistakeId = mistakeService.save(request, TEST_USER_ID);
 
@@ -43,7 +43,7 @@ public class MistakeController {
     }
 
     @PostMapping("/delete")
-    public ResponseEntity<?> deleteMistake(
+    public ResponseEntity<Void> deleteMistake(
             @RequestBody List<Long> ids) {
         mistakeService.deleteMistake(TEST_USER_ID, ids);
 

--- a/src/main/java/weavers/siltarae/mistake/controller/MistakeController.java
+++ b/src/main/java/weavers/siltarae/mistake/controller/MistakeController.java
@@ -12,6 +12,7 @@ import weavers.siltarae.mistake.dto.response.MistakeResponse;
 import weavers.siltarae.mistake.service.MistakeService;
 
 import java.net.URI;
+import java.util.List;
 
 @Tag(name = "[실수] 실수 Controller")
 @RestController
@@ -39,5 +40,13 @@ public class MistakeController {
     public ResponseEntity<MistakeResponse> getMistake(
             @PathVariable("mistakeId") Long mistakeId) {
         return ResponseEntity.ok(mistakeService.getMistake(TEST_USER_ID, mistakeId));
+    }
+
+    @PostMapping("/delete")
+    public ResponseEntity<?> deleteMistake(
+            @RequestBody List<Long> ids) {
+        mistakeService.deleteMistake(TEST_USER_ID, ids);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/weavers/siltarae/mistake/controller/MistakeController.java
+++ b/src/main/java/weavers/siltarae/mistake/controller/MistakeController.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import weavers.siltarae.mistake.dto.request.MistakeCreateRequest;
 import weavers.siltarae.mistake.dto.response.MistakeListResponse;
+import weavers.siltarae.mistake.dto.response.MistakeResponse;
 import weavers.siltarae.mistake.service.MistakeService;
 
 import java.net.URI;
@@ -32,5 +33,11 @@ public class MistakeController {
     @GetMapping
     public ResponseEntity<MistakeListResponse> getMistakes(Pageable pageable) {
         return ResponseEntity.ok(mistakeService.getMistakeList(TEST_USER_ID, pageable));
+    }
+
+    @GetMapping("/{mistakeId}")
+    public ResponseEntity<MistakeResponse> getMistake(
+            @PathVariable("mistakeId") Long mistakeId) {
+        return ResponseEntity.ok(mistakeService.getMistake(TEST_USER_ID, mistakeId));
     }
 }

--- a/src/main/java/weavers/siltarae/mistake/controller/MistakeController.java
+++ b/src/main/java/weavers/siltarae/mistake/controller/MistakeController.java
@@ -3,9 +3,11 @@ package weavers.siltarae.mistake.controller;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import weavers.siltarae.mistake.dto.request.MistakeCreateRequest;
+import weavers.siltarae.mistake.dto.response.MistakeListResponse;
 import weavers.siltarae.mistake.service.MistakeService;
 
 import java.net.URI;
@@ -25,5 +27,10 @@ public class MistakeController {
         Long mistakeId = mistakeService.save(request, TEST_USER_ID);
 
         return ResponseEntity.created(URI.create("mistakes/" + mistakeId)).build();
+    }
+
+    @GetMapping
+    public ResponseEntity<MistakeListResponse> getMistakes(Pageable pageable) {
+        return ResponseEntity.ok(mistakeService.getMistakeList(TEST_USER_ID, pageable));
     }
 }

--- a/src/main/java/weavers/siltarae/mistake/domain/Mistake.java
+++ b/src/main/java/weavers/siltarae/mistake/domain/Mistake.java
@@ -48,4 +48,10 @@ public class Mistake {
         this.createdAt = createdAt;
         this.tags = tags;
     }
+
+    public Mistake deleteMistake(Mistake mistake) {
+        mistake.deletedAt = LocalDateTime.now();
+
+        return mistake;
+    }
 }

--- a/src/main/java/weavers/siltarae/mistake/domain/Mistake.java
+++ b/src/main/java/weavers/siltarae/mistake/domain/Mistake.java
@@ -49,9 +49,7 @@ public class Mistake {
         this.tags = tags;
     }
 
-    public Mistake deleteMistake(Mistake mistake) {
+    public void deleteMistake(Mistake mistake) {
         mistake.deletedAt = LocalDateTime.now();
-
-        return mistake;
     }
 }

--- a/src/main/java/weavers/siltarae/mistake/domain/repository/MistakeRepository.java
+++ b/src/main/java/weavers/siltarae/mistake/domain/repository/MistakeRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import weavers.siltarae.mistake.domain.Mistake;
 import weavers.siltarae.user.domain.User;
 
+import java.util.Optional;
+
 public interface MistakeRepository extends JpaRepository<Mistake, Long> {
-    Page<Mistake> findByUserOrderByIdDesc(User user, Pageable pageable);
+    Page<Mistake> findByUserAndDeletedAtIsNullOrderByIdDesc(User user, Pageable pageable);
 }

--- a/src/main/java/weavers/siltarae/mistake/domain/repository/MistakeRepository.java
+++ b/src/main/java/weavers/siltarae/mistake/domain/repository/MistakeRepository.java
@@ -1,7 +1,11 @@
 package weavers.siltarae.mistake.domain.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import weavers.siltarae.mistake.domain.Mistake;
+import weavers.siltarae.user.domain.User;
 
 public interface MistakeRepository extends JpaRepository<Mistake, Long> {
+    Page<Mistake> findByUserOrderByIdDesc(User user, Pageable pageable);
 }

--- a/src/main/java/weavers/siltarae/mistake/domain/repository/MistakeRepository.java
+++ b/src/main/java/weavers/siltarae/mistake/domain/repository/MistakeRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 
 public interface MistakeRepository extends JpaRepository<Mistake, Long> {
     Page<Mistake> findByUserAndDeletedAtIsNullOrderByIdDesc(User user, Pageable pageable);
+    Optional<Mistake> findByIdAndUserAndDeletedAtIsNull(Long id, User user);
 }

--- a/src/main/java/weavers/siltarae/mistake/domain/repository/MistakeRepository.java
+++ b/src/main/java/weavers/siltarae/mistake/domain/repository/MistakeRepository.java
@@ -6,9 +6,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import weavers.siltarae.mistake.domain.Mistake;
 import weavers.siltarae.user.domain.User;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MistakeRepository extends JpaRepository<Mistake, Long> {
     Page<Mistake> findByUserAndDeletedAtIsNullOrderByIdDesc(User user, Pageable pageable);
     Optional<Mistake> findByIdAndUserAndDeletedAtIsNull(Long id, User user);
+    List<Mistake> findByIdInAndUserAndDeletedAtIsNull(List<Long> id, User user);
 }

--- a/src/main/java/weavers/siltarae/mistake/dto/response/MistakeListResponse.java
+++ b/src/main/java/weavers/siltarae/mistake/dto/response/MistakeListResponse.java
@@ -3,8 +3,11 @@ package weavers.siltarae.mistake.dto.response;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+import weavers.siltarae.mistake.domain.Mistake;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static lombok.AccessLevel.PROTECTED;
 
@@ -18,5 +21,16 @@ public class MistakeListResponse {
     public MistakeListResponse(Long totalCount, List<MistakeResponse> mistakes) {
         this.totalCount = totalCount;
         this.mistakes = mistakes;
+    }
+
+    public static MistakeListResponse from (Page<Mistake> mistakes) {
+        List<MistakeResponse> mistakeResponses = mistakes.getContent().stream().map(
+                MistakeResponse::from
+        ).collect(Collectors.toList());
+
+        return MistakeListResponse.builder()
+                .totalCount(mistakes.getTotalElements())
+                .mistakes(mistakeResponses)
+                .build();
     }
 }

--- a/src/main/java/weavers/siltarae/mistake/dto/response/MistakeListResponse.java
+++ b/src/main/java/weavers/siltarae/mistake/dto/response/MistakeListResponse.java
@@ -1,0 +1,22 @@
+package weavers.siltarae.mistake.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class MistakeListResponse {
+    private Long totalCount;
+    private List<MistakeResponse> mistakes;
+
+    @Builder
+    public MistakeListResponse(Long totalCount, List<MistakeResponse> mistakes) {
+        this.totalCount = totalCount;
+        this.mistakes = mistakes;
+    }
+}

--- a/src/main/java/weavers/siltarae/mistake/dto/response/MistakeResponse.java
+++ b/src/main/java/weavers/siltarae/mistake/dto/response/MistakeResponse.java
@@ -3,6 +3,7 @@ package weavers.siltarae.mistake.dto.response;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import weavers.siltarae.tag.dto.response.TagResponse;
 
 import java.util.List;
 

--- a/src/main/java/weavers/siltarae/mistake/dto/response/MistakeResponse.java
+++ b/src/main/java/weavers/siltarae/mistake/dto/response/MistakeResponse.java
@@ -3,9 +3,11 @@ package weavers.siltarae.mistake.dto.response;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import weavers.siltarae.mistake.domain.Mistake;
 import weavers.siltarae.tag.dto.response.TagResponse;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static lombok.AccessLevel.PROTECTED;
 
@@ -26,5 +28,22 @@ public class MistakeResponse {
         this.tags = tags;
         this.commentCount = commentCount;
         this.likeCount = likeCount;
+    }
+
+    private static final Integer TEST_COMMENT_COUNT = 13;
+    private static final Integer TEST_LIKE_COUNT = 11;
+
+    public static MistakeResponse from(Mistake mistake) {
+        List<TagResponse> tag = mistake.getTags().stream().map(
+                TagResponse::from
+        ).collect(Collectors.toList());
+
+        return MistakeResponse.builder()
+                .id(mistake.getId())
+                .content(mistake.getContent())
+                .commentCount(TEST_COMMENT_COUNT)
+                .likeCount(TEST_LIKE_COUNT)
+                .tags(tag)
+                .build();
     }
 }

--- a/src/main/java/weavers/siltarae/mistake/dto/response/MistakeResponse.java
+++ b/src/main/java/weavers/siltarae/mistake/dto/response/MistakeResponse.java
@@ -1,0 +1,29 @@
+package weavers.siltarae.mistake.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+import static lombok.AccessLevel.PROTECTED;
+
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class MistakeResponse {
+    private Long id;
+    private String content;
+    private List<TagResponse> tags;
+    private Integer commentCount;
+    private Integer likeCount;
+
+    @Builder
+    public MistakeResponse(Long id, String content, List<TagResponse> tags, Integer commentCount, Integer likeCount) {
+        this.id = id;
+        this.content = content;
+        this.tags = tags;
+        this.commentCount = commentCount;
+        this.likeCount = likeCount;
+    }
+}

--- a/src/main/java/weavers/siltarae/mistake/dto/response/TagResponse.java
+++ b/src/main/java/weavers/siltarae/mistake/dto/response/TagResponse.java
@@ -1,0 +1,20 @@
+package weavers.siltarae.mistake.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class TagResponse {
+    private Long id;
+    private String name;
+
+    @Builder
+    public TagResponse(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+}

--- a/src/main/java/weavers/siltarae/mistake/service/MistakeService.java
+++ b/src/main/java/weavers/siltarae/mistake/service/MistakeService.java
@@ -49,55 +49,20 @@ public class MistakeService {
         return mistake.getId();
     }
 
-    private static final Integer TEST_COMMENT_COUNT = 13;
-    private static final Integer TEST_LIKE_COUNT = 11;
-
+    @Transactional(readOnly = true)
     public MistakeListResponse getMistakeList(Long memberId, Pageable pageable) {
         Page<Mistake> mistakes = mistakeRepository.findByUserAndDeletedAtIsNullOrderByIdDesc(getTestUser(memberId), pageable);
 
-        return MistakeListResponse.builder()
-                .totalCount(mistakes.getTotalElements())
-                .mistakes(
-                        mistakes.getContent().stream().map(
-                                mistake -> MistakeResponse.builder()
-                                        .id(mistake.getId())
-                                        .content(mistake.getContent())
-                                        .commentCount(TEST_COMMENT_COUNT)
-                                        .likeCount(TEST_LIKE_COUNT)
-                                        .tags(
-                                                mistake.getTags().stream().map(
-                                                        tag -> TagResponse.builder()
-                                                                .id(tag.getId())
-                                                                .name(tag.getName())
-                                                                .build()
-                                                ).collect(Collectors.toList())
-                                        )
-                                        .build()
-                        ).collect(Collectors.toList())
-                )
-                .build();
+        return MistakeListResponse.from(mistakes);
     }
 
-
+    @Transactional(readOnly = true)
     public MistakeResponse getMistake(Long memberId, Long mistakeId) {
         Mistake mistake = mistakeRepository.findByIdAndUserAndDeletedAtIsNull(mistakeId, getTestUser(memberId)).orElseThrow(
                 () -> new BadRequestException(ExceptionCode.NOT_FOUND_MISTAKE)
         );
 
-        return MistakeResponse.builder()
-                .id(mistake.getId())
-                .content(mistake.getContent())
-                .commentCount(TEST_COMMENT_COUNT)
-                .likeCount(TEST_LIKE_COUNT)
-                .tags(
-                        mistake.getTags().stream().map(
-                                tag -> TagResponse.builder()
-                                        .id(tag.getId())
-                                        .name(tag.getName())
-                                        .build()
-                        ).collect(Collectors.toList())
-                )
-                .build();
+        return MistakeResponse.from(mistake);
     }
 
     @Transactional

--- a/src/main/java/weavers/siltarae/mistake/service/MistakeService.java
+++ b/src/main/java/weavers/siltarae/mistake/service/MistakeService.java
@@ -99,6 +99,17 @@ public class MistakeService {
                 .build();
     }
 
+    public void deleteMistake(Long memberId, List<Long> mistakeIds) {
+        List<Mistake> mistakes
+                = mistakeRepository.findByIdInAndUserAndDeletedAtIsNull(mistakeIds, getTestUser(memberId));
+
+        List<Mistake> deleteMistakes = mistakes.stream()
+                .map(mistake -> mistake.deleteMistake(mistake))
+                .collect(Collectors.toList());
+
+        mistakeRepository.saveAll(deleteMistakes);
+    }
+
     private static final int MAX_MISTAKE_CONTENT_SIZE = 140;
     private static final int MIN_MISTAKE_CONTENT_SIZE = 0;
     private void validateOfMistakeContent(String content) {

--- a/src/main/java/weavers/siltarae/mistake/service/MistakeService.java
+++ b/src/main/java/weavers/siltarae/mistake/service/MistakeService.java
@@ -52,7 +52,7 @@ public class MistakeService {
     private static final Integer TEST_LIKE_COUNT = 11;
 
     public MistakeListResponse getMistakeList(Long memberId, Pageable pageable) {
-        Page<Mistake> mistakes = mistakeRepository.findByUserOrderByIdDesc(getTestUser(memberId), pageable);
+        Page<Mistake> mistakes = mistakeRepository.findByUserAndDeletedAtIsNullOrderByIdDesc(getTestUser(memberId), pageable);
 
         return MistakeListResponse.builder()
                 .totalCount(mistakes.getTotalElements())

--- a/src/main/java/weavers/siltarae/mistake/service/MistakeService.java
+++ b/src/main/java/weavers/siltarae/mistake/service/MistakeService.java
@@ -77,6 +77,28 @@ public class MistakeService {
                 .build();
     }
 
+
+    public MistakeResponse getMistake(Long memberId, Long mistakeId) {
+        Mistake mistake = mistakeRepository.findByIdAndUserAndDeletedAtIsNull(mistakeId, getTestUser(memberId)).orElseThrow(
+                () -> new BadRequestException(ExceptionCode.NOT_FOUND_MISTAKE)
+        );
+
+        return MistakeResponse.builder()
+                .id(mistake.getId())
+                .content(mistake.getContent())
+                .commentCount(TEST_COMMENT_COUNT)
+                .likeCount(TEST_LIKE_COUNT)
+                .tags(
+                        mistake.getTags().stream().map(
+                                tag -> TagResponse.builder()
+                                        .id(tag.getId())
+                                        .name(tag.getName())
+                                        .build()
+                        ).collect(Collectors.toList())
+                )
+                .build();
+    }
+
     private static final int MAX_MISTAKE_CONTENT_SIZE = 140;
     private static final int MIN_MISTAKE_CONTENT_SIZE = 0;
     private void validateOfMistakeContent(String content) {

--- a/src/main/java/weavers/siltarae/mistake/service/MistakeService.java
+++ b/src/main/java/weavers/siltarae/mistake/service/MistakeService.java
@@ -58,8 +58,8 @@ public class MistakeService {
 
     @Transactional(readOnly = true)
     public MistakeResponse getMistake(Long memberId, Long mistakeId) {
-        Mistake mistake = mistakeRepository.findByIdAndUserAndDeletedAtIsNull(mistakeId, getTestUser(memberId)).orElseThrow(
-                () -> new BadRequestException(ExceptionCode.NOT_FOUND_MISTAKE)
+        Mistake mistake = mistakeRepository.findByIdAndUserAndDeletedAtIsNull(mistakeId, getTestUser(memberId))
+        .orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_MISTAKE)
         );
 
         return MistakeResponse.from(mistake);

--- a/src/main/java/weavers/siltarae/mistake/service/MistakeService.java
+++ b/src/main/java/weavers/siltarae/mistake/service/MistakeService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import weavers.siltarae.global.exception.BadRequestException;
 import weavers.siltarae.global.exception.ExceptionCode;
 import weavers.siltarae.mistake.domain.Mistake;
@@ -12,9 +13,9 @@ import weavers.siltarae.mistake.domain.repository.MistakeRepository;
 import weavers.siltarae.mistake.dto.request.MistakeCreateRequest;
 import weavers.siltarae.mistake.dto.response.MistakeListResponse;
 import weavers.siltarae.mistake.dto.response.MistakeResponse;
-import weavers.siltarae.mistake.dto.response.TagResponse;
 import weavers.siltarae.tag.domain.Tag;
 import weavers.siltarae.tag.domain.repository.TagRepository;
+import weavers.siltarae.tag.dto.response.TagResponse;
 import weavers.siltarae.user.domain.User;
 import weavers.siltarae.user.domain.repository.UserRepository;
 
@@ -99,15 +100,14 @@ public class MistakeService {
                 .build();
     }
 
+    @Transactional
     public void deleteMistake(Long memberId, List<Long> mistakeIds) {
         List<Mistake> mistakes
                 = mistakeRepository.findByIdInAndUserAndDeletedAtIsNull(mistakeIds, getTestUser(memberId));
 
-        List<Mistake> deleteMistakes = mistakes.stream()
-                .map(mistake -> mistake.deleteMistake(mistake))
-                .collect(Collectors.toList());
-
-        mistakeRepository.saveAll(deleteMistakes);
+        mistakes.forEach(
+                mistake -> mistake.deleteMistake(mistake)
+        );
     }
 
     private static final int MAX_MISTAKE_CONTENT_SIZE = 140;

--- a/src/main/java/weavers/siltarae/tag/controller/TagController.java
+++ b/src/main/java/weavers/siltarae/tag/controller/TagController.java
@@ -1,0 +1,27 @@
+package weavers.siltarae.tag.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import weavers.siltarae.tag.dto.request.TagCreateRequest;
+import weavers.siltarae.tag.service.TagService;
+
+@RestController
+@RequestMapping("/api/v1/category")
+@RequiredArgsConstructor
+public class TagController {
+
+    private final Long TEMP_USER_ID = 1L;
+
+    private final TagService tagService;
+
+    @PostMapping
+    public ResponseEntity<Void> createTag(@RequestBody @Valid final TagCreateRequest request) {
+        tagService.save(TEMP_USER_ID, request);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/weavers/siltarae/tag/domain/repository/TagRepository.java
+++ b/src/main/java/weavers/siltarae/tag/domain/repository/TagRepository.java
@@ -4,5 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import weavers.siltarae.tag.domain.Tag;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
-    boolean existsByUser_UserIdAndName(Long userId, String name);
+    boolean existsByUser_IdAndName(Long userId, String name);
 }

--- a/src/main/java/weavers/siltarae/tag/domain/repository/TagRepository.java
+++ b/src/main/java/weavers/siltarae/tag/domain/repository/TagRepository.java
@@ -4,4 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import weavers.siltarae.tag.domain.Tag;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
+    boolean existsByUser_UserIdAndName(Long userId, String name);
 }

--- a/src/main/java/weavers/siltarae/tag/dto/request/TagCreateRequest.java
+++ b/src/main/java/weavers/siltarae/tag/dto/request/TagCreateRequest.java
@@ -1,0 +1,26 @@
+package weavers.siltarae.tag.dto.request;
+
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TagCreateRequest {
+
+    @NotEmpty(message = "태그명을 입력해주세요.")
+    @Length(max = 10, message = "태그명은 최대 10자입니다.")
+    @Pattern(regexp = "^[0-9a-zA-Zㄱ-ㅎ가-힣_]*$", message = "태그명에는 한글, 영어, 숫자, _만 사용 가능합니다.")
+    private String name;
+
+    @Builder
+    public TagCreateRequest(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/weavers/siltarae/tag/dto/response/TagResponse.java
+++ b/src/main/java/weavers/siltarae/tag/dto/response/TagResponse.java
@@ -1,4 +1,4 @@
-package weavers.siltarae.mistake.dto.response;
+package weavers.siltarae.tag.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/weavers/siltarae/tag/dto/response/TagResponse.java
+++ b/src/main/java/weavers/siltarae/tag/dto/response/TagResponse.java
@@ -3,6 +3,7 @@ package weavers.siltarae.tag.dto.response;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import weavers.siltarae.tag.domain.Tag;
 
 import static lombok.AccessLevel.PROTECTED;
 
@@ -16,5 +17,12 @@ public class TagResponse {
     public TagResponse(Long id, String name) {
         this.id = id;
         this.name = name;
+    }
+
+    public static TagResponse from(Tag tag) {
+        return TagResponse.builder()
+                .id(tag.getId())
+                .name(tag.getName())
+                .build();
     }
 }

--- a/src/main/java/weavers/siltarae/tag/service/TagService.java
+++ b/src/main/java/weavers/siltarae/tag/service/TagService.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import weavers.siltarae.global.exception.BadRequestException;
-import weavers.siltarae.global.exception.ExceptionCode;
 import weavers.siltarae.tag.domain.repository.TagRepository;
 import weavers.siltarae.tag.domain.Tag;
 import weavers.siltarae.tag.dto.request.TagCreateRequest;
@@ -44,6 +43,6 @@ public class TagService {
     }
 
     private boolean checkDuplicateTagName(final Long userId, final String tagName) {
-        return tagRepository.existsByUser_UserIdAndName(userId, tagName);
+        return tagRepository.existsByUser_IdAndName(userId, tagName);
     }
 }

--- a/src/main/java/weavers/siltarae/tag/service/TagService.java
+++ b/src/main/java/weavers/siltarae/tag/service/TagService.java
@@ -1,0 +1,49 @@
+package weavers.siltarae.tag.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import weavers.siltarae.global.exception.BadRequestException;
+import weavers.siltarae.global.exception.ExceptionCode;
+import weavers.siltarae.tag.domain.repository.TagRepository;
+import weavers.siltarae.tag.domain.Tag;
+import weavers.siltarae.tag.dto.request.TagCreateRequest;
+import weavers.siltarae.user.domain.User;
+import weavers.siltarae.user.domain.repository.UserRepository;
+
+import java.time.LocalDateTime;
+
+import static weavers.siltarae.global.exception.ExceptionCode.*;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TagService {
+
+    private final TagRepository tagRepository;
+
+    private final UserRepository userRepository;
+
+    public Long save(final Long userId, final TagCreateRequest tagCreateRequest) {
+        final User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BadRequestException(INVALID_REQUEST));
+
+        if (checkDuplicateTagName(user.getId(), tagCreateRequest.getName())) {
+            throw new BadRequestException(DUPLICATED_TAG_NAME);
+        }
+
+        final Tag createdTag = Tag.builder()
+                .name(tagCreateRequest.getName())
+                .user(user)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        Tag tag = tagRepository.save(createdTag);
+
+        return tag.getId();
+    }
+
+    private boolean checkDuplicateTagName(final Long userId, final String tagName) {
+        return tagRepository.existsByUser_UserIdAndName(userId, tagName);
+    }
+}

--- a/src/test/java/weavers/siltarae/tag/TagTestFixture.java
+++ b/src/test/java/weavers/siltarae/tag/TagTestFixture.java
@@ -1,0 +1,16 @@
+package weavers.siltarae.tag;
+
+import weavers.siltarae.tag.domain.Tag;
+
+import java.time.LocalDateTime;
+
+public class TagTestFixture {
+
+    public static Tag COMPANY_TAG() {
+        return Tag.builder()
+                .id(1L)
+                .name("회사")
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/test/java/weavers/siltarae/tag/controller/TagControllerTest.java
+++ b/src/test/java/weavers/siltarae/tag/controller/TagControllerTest.java
@@ -1,0 +1,73 @@
+package weavers.siltarae.tag.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import weavers.siltarae.tag.dto.request.TagCreateRequest;
+import weavers.siltarae.tag.service.TagService;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(TagController.class)
+class TagControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private TagService tagService;
+
+    @Test
+    void 태그_등록_요청을_성공한다() throws Exception {
+        // given
+        final TagCreateRequest tagCreateRequest = new TagCreateRequest("tag_Name");
+        
+
+        // when
+        final ResultActions resultActions = mockMvc.perform(post("/api/v1/category")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(tagCreateRequest)));
+
+        // then
+        resultActions.andExpect(status().isNoContent());
+    }
+
+    @Test
+    void 태그명_10자_초과_시_예외가_발생한다() throws Exception {
+        // given
+        final TagCreateRequest tagCreateRequest = new TagCreateRequest("VeryLongTagName");
+
+        // when
+        final ResultActions resultActions = mockMvc.perform(post("/api/v1/category")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(tagCreateRequest)));
+
+        // then
+        resultActions.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("태그명은 최대 10자입니다."));
+    }
+
+    @Test
+    void 태그명에_특수문자가_있으면_예외가_발생한다() throws Exception {
+        // given
+        final TagCreateRequest tagCreateRequest = new TagCreateRequest("Tag$name");
+
+        // when
+        final ResultActions resultActions = mockMvc.perform(post("/api/v1/category")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(tagCreateRequest)));
+
+        // then
+        resultActions.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("태그명에는 한글, 영어, 숫자, _만 사용 가능합니다."));
+    }
+}

--- a/src/test/java/weavers/siltarae/tag/service/TagServiceTest.java
+++ b/src/test/java/weavers/siltarae/tag/service/TagServiceTest.java
@@ -1,0 +1,67 @@
+package weavers.siltarae.tag.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import weavers.siltarae.global.exception.BadRequestException;
+import weavers.siltarae.tag.domain.repository.TagRepository;
+import weavers.siltarae.tag.domain.Tag;
+import weavers.siltarae.tag.dto.request.TagCreateRequest;
+import weavers.siltarae.user.domain.repository.UserRepository;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+import static weavers.siltarae.tag.TagTestFixture.COMPANY_TAG;
+import static weavers.siltarae.user.UserTestFixture.USER_KIM;
+
+@ExtendWith(MockitoExtension.class)
+class TagServiceTest {
+
+    @InjectMocks
+    private TagService tagService;
+
+    @Mock
+    private TagRepository tagRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Test
+    void 태그_생성_후_tagId를_반환한다() {
+        // given
+        final TagCreateRequest tagCreateRequest = new TagCreateRequest("tagName");
+        given(userRepository.findById(anyLong()))
+                .willReturn(Optional.ofNullable(USER_KIM()));
+        given(tagRepository.save(any(Tag.class)))
+                .willReturn(COMPANY_TAG());
+
+        // when
+        final Long actualId = tagService.save(1L, tagCreateRequest);
+
+        // then
+        assertThat(actualId).isEqualTo(1L);
+    }
+
+    @Test
+    void 태그명_중복_시_예외가_발생한다() {
+        // given
+        TagCreateRequest request = new TagCreateRequest("회사");
+        given(userRepository.findById(anyLong()))
+                .willReturn(Optional.ofNullable(USER_KIM()));
+        given(tagRepository.existsByUser_UserIdAndName(1L, "회사"))
+                .willReturn(true);
+
+        // when
+        BadRequestException e = assertThrows(BadRequestException.class,
+                () -> tagService.save(1L, request));
+
+        // then
+        assertThat(e.getMessage()).isEqualTo("중복된 태그명입니다.");
+    }
+}

--- a/src/test/java/weavers/siltarae/tag/service/TagServiceTest.java
+++ b/src/test/java/weavers/siltarae/tag/service/TagServiceTest.java
@@ -54,7 +54,7 @@ class TagServiceTest {
         TagCreateRequest request = new TagCreateRequest("회사");
         given(userRepository.findById(anyLong()))
                 .willReturn(Optional.ofNullable(USER_KIM()));
-        given(tagRepository.existsByUser_UserIdAndName(1L, "회사"))
+        given(tagRepository.existsByUser_IdAndName(1L, "회사"))
                 .willReturn(true);
 
         // when

--- a/src/test/java/weavers/siltarae/user/UserTestFixture.java
+++ b/src/test/java/weavers/siltarae/user/UserTestFixture.java
@@ -1,0 +1,19 @@
+package weavers.siltarae.user;
+
+import weavers.siltarae.user.domain.SocialType;
+import weavers.siltarae.user.domain.User;
+
+import java.time.LocalDateTime;
+
+public class UserTestFixture {
+
+    public static User USER_KIM() {
+        return User.builder()
+                .id(1L)
+                .email("siltarae@nn.com")
+                .createdAt(LocalDateTime.now())
+                .nickname("Kim")
+                .socialType(SocialType.GOOGLE)
+                .build();
+    }
+}


### PR DESCRIPTION
## 🔥 관련 이슈
Issue: #3 

## ✨ 변경사항
- 나의 실수 리스트 조회 API 를 구현하였습니다.
- 나의 실수 상세 보기 API 를 구현하였습니다.
- 실수 선택 삭제 API 를 구현하였습니다.

## 📝 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?

