### PR TITLE
bug: [#4] TagRepository 쿼리메서드명 수정

### DIFF
--- a/src/main/java/weavers/siltarae/tag/domain/repository/TagRepository.java
+++ b/src/main/java/weavers/siltarae/tag/domain/repository/TagRepository.java
@@ -4,5 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import weavers.siltarae.tag.domain.Tag;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
-    boolean existsByUser_UserIdAndName(Long userId, String name);
+    boolean existsByUser_IdAndName(Long userId, String name);
 }

--- a/src/main/java/weavers/siltarae/tag/service/TagService.java
+++ b/src/main/java/weavers/siltarae/tag/service/TagService.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import weavers.siltarae.global.exception.BadRequestException;
-import weavers.siltarae.global.exception.ExceptionCode;
 import weavers.siltarae.tag.domain.repository.TagRepository;
 import weavers.siltarae.tag.domain.Tag;
 import weavers.siltarae.tag.dto.request.TagCreateRequest;
@@ -44,6 +43,6 @@ public class TagService {
     }
 
     private boolean checkDuplicateTagName(final Long userId, final String tagName) {
-        return tagRepository.existsByUser_UserIdAndName(userId, tagName);
+        return tagRepository.existsByUser_IdAndName(userId, tagName);
     }
 }

--- a/src/test/java/weavers/siltarae/tag/service/TagServiceTest.java
+++ b/src/test/java/weavers/siltarae/tag/service/TagServiceTest.java
@@ -54,7 +54,7 @@ class TagServiceTest {
         TagCreateRequest request = new TagCreateRequest("회사");
         given(userRepository.findById(anyLong()))
                 .willReturn(Optional.ofNullable(USER_KIM()));
-        given(tagRepository.existsByUser_UserIdAndName(1L, "회사"))
+        given(tagRepository.existsByUser_IdAndName(1L, "회사"))
                 .willReturn(true);
 
         // when


### PR DESCRIPTION
## 🔥 관련 이슈
close #4 

## ✨ 변경사항
TagRepository의 `existsByUser_UserIdAndName`을 `existsByUser_IdAndName`으로 수정했습니다.

## 📝 작업 유형
- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
