### PR TITLE
feat: [#5] 실수 등록 시 검증 로직 변경 및 실수 내용 특수문자 허용

### DIFF
--- a/src/main/java/weavers/siltarae/mistake/service/MistakeService.java
+++ b/src/main/java/weavers/siltarae/mistake/service/MistakeService.java
@@ -35,8 +35,6 @@ public class MistakeService {
 
     public Long save(
             MistakeCreateRequest request, Long memberId) {
-        validateOfMistakeContent(request.getContent());
-
         Mistake mistake = mistakeRepository.save(
                 Mistake.builder()
                         .user(getTestUser(memberId))
@@ -73,35 +71,6 @@ public class MistakeService {
         mistakes.forEach(
                 mistake -> mistake.deleteMistake(mistake)
         );
-    }
-
-    private static final int MAX_MISTAKE_CONTENT_SIZE = 140;
-    private static final int MIN_MISTAKE_CONTENT_SIZE = 0;
-    private void validateOfMistakeContent(String content) {
-        validateMaxSizeMistakeContent(content);
-        validateMinSizeMistakeContent(content);
-
-        validateMistakeContent(content);
-    }
-
-    private void validateMistakeContent(String content) {
-        boolean test = Pattern.matches("^[0-9a-zA-Zㄱ-ㅎ가-힣 .,]*$", content);
-
-        if (!test) {
-            throw new BadRequestException(ExceptionCode.INVALID_MISTAKE_CONTENT);
-        }
-    }
-
-    private void validateMinSizeMistakeContent(String content) {
-        if (content.length() == MIN_MISTAKE_CONTENT_SIZE) {
-            throw new BadRequestException(ExceptionCode.INVALID_MISTAKE_CONTENT_NULL);
-        }
-    }
-
-    private void validateMaxSizeMistakeContent(String content) {
-        if (content.length() > MAX_MISTAKE_CONTENT_SIZE) {
-            throw new BadRequestException(ExceptionCode.INVALID_MISTAKE_CONTENT_SIZE);
-        }
     }
 
     private User getTestUser(Long memberId) {


### PR DESCRIPTION
## 🔥 관련 이슈
close #5 

## ✨ 변경사항
- 실수 등록 시 검증을 RequestDto 에서 진행하기 때문에 Service 까지 재검증할 필요성이 없다고 생각되어 메소드 삭제
- 기획 회의 상에서 실수 내용에 특수문자를 허용하게끔 했기때문에 해당 내용 메소드 삭제

## 📝 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?

