### PR TITLE
bug: [#4] 제약조건에 맞게 태그명 검증 수정

### DIFF
--- a/src/main/java/weavers/siltarae/tag/dto/request/TagCreateRequest.java
+++ b/src/main/java/weavers/siltarae/tag/dto/request/TagCreateRequest.java
@@ -1,7 +1,6 @@
 package weavers.siltarae.tag.dto.request;
 
 
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 import lombok.AccessLevel;
@@ -16,7 +15,7 @@ public class TagCreateRequest {
 
     @NotEmpty(message = "태그명을 입력해주세요.")
     @Length(max = 10, message = "태그명은 최대 10자입니다.")
-    @Pattern(regexp = "^[0-9a-zA-Zㄱ-ㅎ가-힣_]*$", message = "태그명에는 한글, 영어, 숫자, _만 사용 가능합니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9가-힣]+(?:_[a-zA-Z0-9가-힣]+)*$", message = "태그명에는 한글, 영어, 숫자, 연속 1개 이하의 _만 사용 가능합니다.")
     private String name;
 
     @Builder


### PR DESCRIPTION
## 🔥 관련 이슈
close #4 

## ✨ 변경사항
태그명 검증에 아래와 같은 제약조건을 추가하였습니다.
- 언더바 연속 2개 이상 사용 불가
- 태그명은 한글, 숫자, 영어로 시작해야 함

## 📝 작업 유형
- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
