### PR TITLE
feat: [#7] 태그 목록 조회, 선택 삭제 기능 구현

### DIFF
--- a/src/main/java/weavers/siltarae/global/exception/ExceptionCode.java
+++ b/src/main/java/weavers/siltarae/global/exception/ExceptionCode.java
@@ -7,12 +7,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ExceptionCode {
     INVALID_REQUEST(1000, "올바르지 않은 요청입니다."),
-    DUPLICATED_TAG_NAME(3001, "중복된 태그명입니다."),
 
     INVALID_MISTAKE_CONTENT_SIZE(2001, "실수 내용은 140자가 넘을 수 없습니다."),
     INVALID_MISTAKE_CONTENT_NULL(2002, "실수 내용은 필수입니다."),
     INVALID_MISTAKE_CONTENT(2003, "실수 내용에는 한글, 영어, 숫자만 허용됩니다."),
     NOT_FOUND_MISTAKE(2004, "해당하는 실수가 존재하지 않습니다."),
+
+    DUPLICATED_TAG_NAME(3001, "중복된 태그명입니다."),
+    NOT_FOUND_TAG(3002, "해당하는 태그가 존재하지 않습니다."),
 
     NOT_FOUND_USER(4001, "해당하는 유저가 존재하지 않습니다."),
 

--- a/src/main/java/weavers/siltarae/tag/controller/TagController.java
+++ b/src/main/java/weavers/siltarae/tag/controller/TagController.java
@@ -8,6 +8,8 @@ import weavers.siltarae.tag.dto.request.TagCreateRequest;
 import weavers.siltarae.tag.dto.response.TagListResponse;
 import weavers.siltarae.tag.service.TagService;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/v1/tags")
 @RequiredArgsConstructor
@@ -29,5 +31,12 @@ public class TagController {
         TagListResponse tagListResponse = tagService.getTagList(TEMP_USER_ID);
 
         return ResponseEntity.ok(tagListResponse);
+    }
+
+    @PostMapping("/delete")
+    public ResponseEntity<Void> deleteTags(@RequestBody final List<Long> tagIdList) {
+        tagService.deleteTags(tagIdList);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/weavers/siltarae/tag/controller/TagController.java
+++ b/src/main/java/weavers/siltarae/tag/controller/TagController.java
@@ -3,15 +3,13 @@ package weavers.siltarae.tag.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import weavers.siltarae.tag.dto.request.TagCreateRequest;
+import weavers.siltarae.tag.dto.response.TagListResponse;
 import weavers.siltarae.tag.service.TagService;
 
 @RestController
-@RequestMapping("/api/v1/category")
+@RequestMapping("/api/v1/tags")
 @RequiredArgsConstructor
 public class TagController {
 
@@ -22,6 +20,14 @@ public class TagController {
     @PostMapping
     public ResponseEntity<Void> createTag(@RequestBody @Valid final TagCreateRequest request) {
         tagService.save(TEMP_USER_ID, request);
+
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<TagListResponse> getTagList() {
+        TagListResponse tagListResponse = tagService.getTagList(TEMP_USER_ID);
+
+        return ResponseEntity.ok(tagListResponse);
     }
 }

--- a/src/main/java/weavers/siltarae/tag/domain/Tag.java
+++ b/src/main/java/weavers/siltarae/tag/domain/Tag.java
@@ -49,6 +49,7 @@ public class Tag {
     }
 
     public void delete() {
+        this.getMistakes().clear();
         this.deletedAt = LocalDateTime.now();
     }
 

--- a/src/main/java/weavers/siltarae/tag/domain/Tag.java
+++ b/src/main/java/weavers/siltarae/tag/domain/Tag.java
@@ -47,4 +47,12 @@ public class Tag {
         this.mistakes = mistakes;
         this.createdAt = createdAt;
     }
+
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public boolean isDeleted() {
+        return (this.deletedAt != null);
+    }
 }

--- a/src/main/java/weavers/siltarae/tag/domain/repository/TagRepository.java
+++ b/src/main/java/weavers/siltarae/tag/domain/repository/TagRepository.java
@@ -3,6 +3,10 @@ package weavers.siltarae.tag.domain.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import weavers.siltarae.tag.domain.Tag;
 
+import java.util.List;
+
 public interface TagRepository extends JpaRepository<Tag, Long> {
     boolean existsByUser_IdAndName(Long userId, String name);
+
+    List<Tag> findAllByUser_Id(Long userId);
 }

--- a/src/main/java/weavers/siltarae/tag/domain/repository/TagRepository.java
+++ b/src/main/java/weavers/siltarae/tag/domain/repository/TagRepository.java
@@ -8,5 +8,5 @@ import java.util.List;
 public interface TagRepository extends JpaRepository<Tag, Long> {
     boolean existsByUser_IdAndName(Long userId, String name);
 
-    List<Tag> findAllByUser_Id(Long userId);
+    List<Tag> findAllByUser_IdAndDeletedAtIsNotNull(Long userId);
 }

--- a/src/main/java/weavers/siltarae/tag/dto/response/TagListResponse.java
+++ b/src/main/java/weavers/siltarae/tag/dto/response/TagListResponse.java
@@ -1,0 +1,35 @@
+package weavers.siltarae.tag.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import weavers.siltarae.tag.domain.Tag;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TagListResponse {
+
+    private Integer totalCount;
+
+    private List<TagResponse> tags;
+
+    @Builder
+    public TagListResponse(Integer totalCount, List<TagResponse> tags) {
+        this.totalCount = totalCount;
+        this.tags = tags;
+    }
+
+    public static TagListResponse from(List<Tag> tagList) {
+        List<TagResponse> tagResponseList = tagList.stream()
+                .map(TagResponse::from).collect(Collectors.toList());
+
+        return TagListResponse.builder()
+                .totalCount(tagResponseList.size())
+                .tags(tagResponseList)
+                .build();
+    }
+}

--- a/src/main/java/weavers/siltarae/tag/dto/response/TagResponse.java
+++ b/src/main/java/weavers/siltarae/tag/dto/response/TagResponse.java
@@ -13,16 +13,20 @@ public class TagResponse {
     private Long id;
     private String name;
 
+    private Integer mistakeCount;
+
     @Builder
-    public TagResponse(Long id, String name) {
+    public TagResponse(Long id, String name, Integer mistakeCount) {
         this.id = id;
         this.name = name;
+        this.mistakeCount = mistakeCount;
     }
 
     public static TagResponse from(Tag tag) {
         return TagResponse.builder()
                 .id(tag.getId())
                 .name(tag.getName())
+                .mistakeCount(tag.getMistakes().size())
                 .build();
     }
 }

--- a/src/main/java/weavers/siltarae/tag/service/TagService.java
+++ b/src/main/java/weavers/siltarae/tag/service/TagService.java
@@ -12,6 +12,7 @@ import weavers.siltarae.user.domain.User;
 import weavers.siltarae.user.domain.repository.UserRepository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static weavers.siltarae.global.exception.ExceptionCode.*;
 
@@ -48,7 +49,23 @@ public class TagService {
         return TagListResponse.from(tagRepository.findAllByUser_Id(userId));
     }
 
+    public void deleteTags(final List<Long> tagIdList) {
+        List<Tag> tagList = tagRepository.findAllById(tagIdList);
+
+        if(hasDeletedTag(tagList)) {
+            throw new BadRequestException(NOT_FOUND_TAG);
+        }
+
+        tagList.forEach(Tag::delete);
+    }
+
     private boolean checkDuplicateTagName(final Long userId, final String tagName) {
         return tagRepository.existsByUser_IdAndName(userId, tagName);
     }
+
+    private boolean hasDeletedTag(List<Tag> tagList) {
+        return tagList.stream().anyMatch(Tag::isDeleted);
+    }
+
+
 }

--- a/src/main/java/weavers/siltarae/tag/service/TagService.java
+++ b/src/main/java/weavers/siltarae/tag/service/TagService.java
@@ -46,7 +46,12 @@ public class TagService {
 
     @Transactional(readOnly = true)
     public TagListResponse getTagList(final Long userId) {
-        return TagListResponse.from(tagRepository.findAllByUser_Id(userId));
+        List<Tag> tagList = tagRepository.findAllByUser_Id(userId)
+                .stream()
+                .filter(tag -> !tag.isDeleted())
+                .toList();
+
+        return TagListResponse.from(tagList);
     }
 
     public void deleteTags(final List<Long> tagIdList) {

--- a/src/main/java/weavers/siltarae/tag/service/TagService.java
+++ b/src/main/java/weavers/siltarae/tag/service/TagService.java
@@ -7,6 +7,7 @@ import weavers.siltarae.global.exception.BadRequestException;
 import weavers.siltarae.tag.domain.repository.TagRepository;
 import weavers.siltarae.tag.domain.Tag;
 import weavers.siltarae.tag.dto.request.TagCreateRequest;
+import weavers.siltarae.tag.dto.response.TagListResponse;
 import weavers.siltarae.user.domain.User;
 import weavers.siltarae.user.domain.repository.UserRepository;
 
@@ -25,7 +26,7 @@ public class TagService {
 
     public Long save(final Long userId, final TagCreateRequest tagCreateRequest) {
         final User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BadRequestException(INVALID_REQUEST));
+                .orElseThrow(() -> new BadRequestException(NOT_FOUND_USER));
 
         if (checkDuplicateTagName(user.getId(), tagCreateRequest.getName())) {
             throw new BadRequestException(DUPLICATED_TAG_NAME);
@@ -40,6 +41,11 @@ public class TagService {
         Tag tag = tagRepository.save(createdTag);
 
         return tag.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public TagListResponse getTagList(final Long userId) {
+        return TagListResponse.from(tagRepository.findAllByUser_Id(userId));
     }
 
     private boolean checkDuplicateTagName(final Long userId, final String tagName) {

--- a/src/main/java/weavers/siltarae/tag/service/TagService.java
+++ b/src/main/java/weavers/siltarae/tag/service/TagService.java
@@ -46,10 +46,7 @@ public class TagService {
 
     @Transactional(readOnly = true)
     public TagListResponse getTagList(final Long userId) {
-        List<Tag> tagList = tagRepository.findAllByUser_Id(userId)
-                .stream()
-                .filter(tag -> !tag.isDeleted())
-                .toList();
+        List<Tag> tagList = tagRepository.findAllByUser_IdAndDeletedAtIsNotNull(userId);
 
         return TagListResponse.from(tagList);
     }

--- a/src/test/java/weavers/siltarae/tag/TagTestFixture.java
+++ b/src/test/java/weavers/siltarae/tag/TagTestFixture.java
@@ -21,4 +21,16 @@ public class TagTestFixture {
                 .createdAt(LocalDateTime.now())
                 .build();
     }
+
+    public static Tag DELETED_TAG() {
+        Tag deletedTag = Tag.builder()
+                            .id(1L)
+                            .name("모의고사")
+                            .createdAt(LocalDateTime.of(2018, 3, 15, 23, 2))
+                            .build();
+
+        deletedTag.delete();
+
+        return deletedTag;
+    }
 }

--- a/src/test/java/weavers/siltarae/tag/TagTestFixture.java
+++ b/src/test/java/weavers/siltarae/tag/TagTestFixture.java
@@ -13,4 +13,12 @@ public class TagTestFixture {
                 .createdAt(LocalDateTime.now())
                 .build();
     }
+
+    public static Tag DAILY_TAG() {
+        return Tag.builder()
+                .id(1L)
+                .name("일상")
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
 }

--- a/src/test/java/weavers/siltarae/tag/controller/TagControllerTest.java
+++ b/src/test/java/weavers/siltarae/tag/controller/TagControllerTest.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -84,8 +84,8 @@ class TagControllerTest {
     @Test
     void 태그_목록_조회_요청에_성공한다() throws Exception {
         // given
-        when(tagService.getTagList(any(Long.class)))
-                .thenReturn(TagListResponse.from(List.of(COMPANY_TAG(), DAILY_TAG())));
+        given(tagService.getTagList(any(Long.class)))
+                .willReturn(TagListResponse.from(List.of(COMPANY_TAG(), DAILY_TAG())));
 
         // when
         final ResultActions resultActions = mockMvc.perform(get("/api/v1/tags")

--- a/src/test/java/weavers/siltarae/tag/controller/TagControllerTest.java
+++ b/src/test/java/weavers/siltarae/tag/controller/TagControllerTest.java
@@ -7,12 +7,22 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import weavers.siltarae.tag.dto.request.TagCreateRequest;
+import weavers.siltarae.tag.dto.response.TagListResponse;
 import weavers.siltarae.tag.service.TagService;
 
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static weavers.siltarae.tag.TagTestFixture.COMPANY_TAG;
+import static weavers.siltarae.tag.TagTestFixture.DAILY_TAG;
 
 @WebMvcTest(TagController.class)
 class TagControllerTest {
@@ -33,7 +43,7 @@ class TagControllerTest {
         
 
         // when
-        final ResultActions resultActions = mockMvc.perform(post("/api/v1/category")
+        final ResultActions resultActions = mockMvc.perform(post("/api/v1/tags")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(tagCreateRequest)));
 
@@ -47,7 +57,7 @@ class TagControllerTest {
         final TagCreateRequest tagCreateRequest = new TagCreateRequest("VeryLongTagName");
 
         // when
-        final ResultActions resultActions = mockMvc.perform(post("/api/v1/category")
+        final ResultActions resultActions = mockMvc.perform(post("/api/v1/tags")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(tagCreateRequest)));
 
@@ -62,12 +72,32 @@ class TagControllerTest {
         final TagCreateRequest tagCreateRequest = new TagCreateRequest("Tag$name");
 
         // when
-        final ResultActions resultActions = mockMvc.perform(post("/api/v1/category")
+        final ResultActions resultActions = mockMvc.perform(post("/api/v1/tags")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(tagCreateRequest)));
 
         // then
         resultActions.andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("태그명에는 한글, 영어, 숫자, _만 사용 가능합니다."));
+    }
+
+    @Test
+    void 태그_목록_조회_요청에_성공한다() throws Exception {
+        // given
+        when(tagService.getTagList(any(Long.class)))
+                .thenReturn(TagListResponse.from(List.of(COMPANY_TAG(), DAILY_TAG())));
+
+        // when
+        final ResultActions resultActions = mockMvc.perform(get("/api/v1/tags")
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        final MvcResult mvcResult = resultActions.andExpect(status().isOk())
+                .andReturn();
+        final TagListResponse tagListResponse = objectMapper.readValue(
+                mvcResult.getResponse().getContentAsString(),
+                TagListResponse.class
+        );
+        assertThat(tagListResponse.getTotalCount()).isEqualTo(2);
     }
 }

--- a/src/test/java/weavers/siltarae/tag/controller/TagControllerTest.java
+++ b/src/test/java/weavers/siltarae/tag/controller/TagControllerTest.java
@@ -21,8 +21,7 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static weavers.siltarae.tag.TagTestFixture.COMPANY_TAG;
-import static weavers.siltarae.tag.TagTestFixture.DAILY_TAG;
+import static weavers.siltarae.tag.TagTestFixture.*;
 
 @WebMvcTest(TagController.class)
 class TagControllerTest {
@@ -99,5 +98,14 @@ class TagControllerTest {
                 TagListResponse.class
         );
         assertThat(tagListResponse.getTotalCount()).isEqualTo(2);
+    }
+
+    @Test
+    void 태그_삭제_요청에_성공한다() {
+        // given
+
+        // when
+
+        // then
     }
 }

--- a/src/test/java/weavers/siltarae/tag/service/TagServiceTest.java
+++ b/src/test/java/weavers/siltarae/tag/service/TagServiceTest.java
@@ -77,7 +77,7 @@ class TagServiceTest {
     @Test
     void 사용자의_태그_목록을_조회할_수_있다() {
         // given
-        given(tagRepository.findAllByUser_Id(1L))
+        given(tagRepository.findAllByUser_IdAndDeletedAtIsNotNull(1L))
                 .willReturn(List.of(COMPANY_TAG(), DAILY_TAG()));
 
         // when

--- a/src/test/java/weavers/siltarae/tag/service/TagServiceTest.java
+++ b/src/test/java/weavers/siltarae/tag/service/TagServiceTest.java
@@ -12,6 +12,7 @@ import weavers.siltarae.tag.dto.request.TagCreateRequest;
 import weavers.siltarae.tag.dto.response.TagListResponse;
 import weavers.siltarae.user.domain.repository.UserRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -37,14 +38,14 @@ class TagServiceTest {
     @Test
     void 태그_생성_후_tagId를_반환한다() {
         // given
-        final TagCreateRequest tagCreateRequest = new TagCreateRequest("tagName");
-        given(userRepository.findById(anyLong()))
+        final TagCreateRequest tagCreateRequest = new TagCreateRequest(COMPANY_TAG.getName());
+        given(userRepository.findById(2L))
                 .willReturn(Optional.ofNullable(USER_KIM()));
         given(tagRepository.save(any(Tag.class)))
-                .willReturn(COMPANY_TAG());
+                .willReturn(COMPANY_TAG);
 
         // when
-        final Long actualId = tagService.save(1L, tagCreateRequest);
+        final Long actualId = tagService.save(2L, tagCreateRequest);
 
         // then
         assertThat(actualId).isEqualTo(1L);
@@ -67,6 +68,12 @@ class TagServiceTest {
         assertThat(e.getMessage()).isEqualTo("중복된 태그명입니다.");
     }
 
+    static Tag COMPANY_TAG = Tag.builder()
+            .id(1L)
+            .name("회사")
+            .createdAt(LocalDateTime.now())
+            .build();
+
     @Test
     void 사용자의_태그_목록을_조회할_수_있다() {
         // given
@@ -85,9 +92,9 @@ class TagServiceTest {
         // given
         given(tagRepository.findAllById(anyList()))
                 .willReturn(List.of(COMPANY_TAG(), DELETED_TAG(), DAILY_TAG()));
+        List<Long> tagIdList = List.of(1L, 2L, 3L);
 
         // when
-        List<Long> tagIdList = List.of(1L, 2L, 3L);
 
         // then
         assertThatThrownBy(() -> tagService.deleteTags(tagIdList))

--- a/src/test/java/weavers/siltarae/tag/service/TagServiceTest.java
+++ b/src/test/java/weavers/siltarae/tag/service/TagServiceTest.java
@@ -19,8 +19,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.*;
-import static weavers.siltarae.tag.TagTestFixture.COMPANY_TAG;
-import static weavers.siltarae.tag.TagTestFixture.DAILY_TAG;
+import static weavers.siltarae.tag.TagTestFixture.*;
 import static weavers.siltarae.user.UserTestFixture.USER_KIM;
 
 @ExtendWith(MockitoExtension.class)
@@ -79,5 +78,20 @@ class TagServiceTest {
 
         // then
         assertThat(tagList.getTotalCount()).isEqualTo(2);
+    }
+
+    @Test
+    void 이미_삭제된_태그를_삭제하면_예외가_발생한다() {
+        // given
+        given(tagRepository.findAllById(anyList()))
+                .willReturn(List.of(COMPANY_TAG(), DELETED_TAG(), DAILY_TAG()));
+
+        // when
+        List<Long> tagIdList = List.of(1L, 2L, 3L);
+
+        // then
+        assertThatThrownBy(() -> tagService.deleteTags(tagIdList))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("해당하는 태그가 존재하지 않습니다.");
     }
 }

--- a/src/test/java/weavers/siltarae/tag/service/TagServiceTest.java
+++ b/src/test/java/weavers/siltarae/tag/service/TagServiceTest.java
@@ -9,8 +9,10 @@ import weavers.siltarae.global.exception.BadRequestException;
 import weavers.siltarae.tag.domain.repository.TagRepository;
 import weavers.siltarae.tag.domain.Tag;
 import weavers.siltarae.tag.dto.request.TagCreateRequest;
+import weavers.siltarae.tag.dto.response.TagListResponse;
 import weavers.siltarae.user.domain.repository.UserRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
@@ -18,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.*;
 import static weavers.siltarae.tag.TagTestFixture.COMPANY_TAG;
+import static weavers.siltarae.tag.TagTestFixture.DAILY_TAG;
 import static weavers.siltarae.user.UserTestFixture.USER_KIM;
 
 @ExtendWith(MockitoExtension.class)
@@ -63,5 +66,18 @@ class TagServiceTest {
 
         // then
         assertThat(e.getMessage()).isEqualTo("중복된 태그명입니다.");
+    }
+
+    @Test
+    void 사용자의_태그_목록을_조회할_수_있다() {
+        // given
+        given(tagRepository.findAllByUser_Id(1L))
+                .willReturn(List.of(COMPANY_TAG(), DAILY_TAG()));
+
+        // when
+        TagListResponse tagList = tagService.getTagList(1L);
+
+        // then
+        assertThat(tagList.getTotalCount()).isEqualTo(2);
     }
 }


### PR DESCRIPTION
## 🔥 관련 이슈
close #7   

## ✨ 변경사항
- 태그 목록 조회 API 및 관련 테스트 구현
- 태그 선택 삭제 API 및 관련 테스트 구현
  - 태그 삭제 요청 시, 이미 삭제된 태그가 포함되어 있는 경우 3002 `NOT_FOUND_TAG` 예외가 발생합니다.

## 📝 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
