### PR TITLE
refactor: [#9] 생성일 자동화

### DIFF
--- a/src/main/java/weavers/siltarae/SiltaraeBeApplication.java
+++ b/src/main/java/weavers/siltarae/SiltaraeBeApplication.java
@@ -2,7 +2,9 @@ package weavers.siltarae;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class SiltaraeBeApplication {
 

--- a/src/main/java/weavers/siltarae/global/BaseEntity.java
+++ b/src/main/java/weavers/siltarae/global/BaseEntity.java
@@ -1,0 +1,30 @@
+package weavers.siltarae.global;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    private LocalDateTime deletedAt;
+
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public boolean isDeleted() {
+        return (this.deletedAt != null);
+    }
+}

--- a/src/main/java/weavers/siltarae/mistake/domain/Mistake.java
+++ b/src/main/java/weavers/siltarae/mistake/domain/Mistake.java
@@ -4,11 +4,10 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
+import weavers.siltarae.global.BaseEntity;
 import weavers.siltarae.tag.domain.Tag;
 import weavers.siltarae.user.domain.User;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import static lombok.AccessLevel.PROTECTED;
@@ -16,7 +15,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class Mistake {
+public class Mistake extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -28,12 +27,6 @@ public class Mistake {
     @Column(nullable = false, length = 140)
     private String content;
 
-    @CreatedDate
-    @Column(updatable = false, nullable = false)
-    private LocalDateTime createdAt;
-
-    private LocalDateTime deletedAt;
-
     @ManyToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @JoinTable(name = "tag_mistake",
             joinColumns = @JoinColumn(name = "mistake_id"),
@@ -41,15 +34,11 @@ public class Mistake {
     private List<Tag> tags;
 
     @Builder
-    public Mistake(Long id, User user, String content, LocalDateTime createdAt, List<Tag> tags) {
+    public Mistake(Long id, User user, String content, List<Tag> tags) {
         this.id = id;
         this.user = user;
         this.content = content;
-        this.createdAt = createdAt;
         this.tags = tags;
     }
 
-    public void deleteMistake(Mistake mistake) {
-        mistake.deletedAt = LocalDateTime.now();
-    }
 }

--- a/src/main/java/weavers/siltarae/mistake/service/MistakeService.java
+++ b/src/main/java/weavers/siltarae/mistake/service/MistakeService.java
@@ -15,15 +15,11 @@ import weavers.siltarae.mistake.dto.response.MistakeListResponse;
 import weavers.siltarae.mistake.dto.response.MistakeResponse;
 import weavers.siltarae.tag.domain.Tag;
 import weavers.siltarae.tag.domain.repository.TagRepository;
-import weavers.siltarae.tag.dto.response.TagResponse;
 import weavers.siltarae.user.domain.User;
 import weavers.siltarae.user.domain.repository.UserRepository;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -39,7 +35,6 @@ public class MistakeService {
                 Mistake.builder()
                         .user(getTestUser(memberId))
                         .content(request.getContent())
-                        .createdAt(LocalDateTime.now())
                         .tags(getTags(request.getTagIds(), memberId))
                         .build()
         );
@@ -68,9 +63,7 @@ public class MistakeService {
         List<Mistake> mistakes
                 = mistakeRepository.findByIdInAndUserAndDeletedAtIsNull(mistakeIds, getTestUser(memberId));
 
-        mistakes.forEach(
-                mistake -> mistake.deleteMistake(mistake)
-        );
+        mistakes.forEach(Mistake::delete);
     }
 
     private User getTestUser(Long memberId) {

--- a/src/main/java/weavers/siltarae/tag/domain/Tag.java
+++ b/src/main/java/weavers/siltarae/tag/domain/Tag.java
@@ -5,17 +5,16 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
+import weavers.siltarae.global.BaseEntity;
 import weavers.siltarae.mistake.domain.Mistake;
 import weavers.siltarae.user.domain.User;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Tag {
+public class Tag extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -33,27 +32,17 @@ public class Tag {
         inverseJoinColumns = @JoinColumn(name = "mistake_id"))
     private List<Mistake> mistakes;
 
-    @CreatedDate
-    @Column(updatable = false, nullable = false)
-    private LocalDateTime createdAt;
-
-    private LocalDateTime deletedAt;
-
     @Builder
-    public Tag(Long id, String name, User user, List<Mistake> mistakes, LocalDateTime createdAt) {
+    public Tag(Long id, String name, User user, List<Mistake> mistakes) {
         this.id = id;
         this.name = name;
         this.user = user;
         this.mistakes = mistakes;
-        this.createdAt = createdAt;
     }
 
+    @Override
     public void delete() {
+        super.delete();
         this.getMistakes().clear();
-        this.deletedAt = LocalDateTime.now();
-    }
-
-    public boolean isDeleted() {
-        return (this.deletedAt != null);
     }
 }

--- a/src/main/java/weavers/siltarae/tag/service/TagService.java
+++ b/src/main/java/weavers/siltarae/tag/service/TagService.java
@@ -11,7 +11,6 @@ import weavers.siltarae.tag.dto.response.TagListResponse;
 import weavers.siltarae.user.domain.User;
 import weavers.siltarae.user.domain.repository.UserRepository;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import static weavers.siltarae.global.exception.ExceptionCode.*;
@@ -36,7 +35,6 @@ public class TagService {
         final Tag createdTag = Tag.builder()
                 .name(tagCreateRequest.getName())
                 .user(user)
-                .createdAt(LocalDateTime.now())
                 .build();
 
         Tag tag = tagRepository.save(createdTag);

--- a/src/main/java/weavers/siltarae/user/domain/User.java
+++ b/src/main/java/weavers/siltarae/user/domain/User.java
@@ -5,14 +5,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
+import weavers.siltarae.global.BaseEntity;
 
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User {
+public class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,23 +26,16 @@ public class User {
     @Column(nullable = false)
     private String email;
 
-    @CreatedDate
-    @Column(updatable = false, nullable = false)
-    private LocalDateTime createdAt;
-
-    private LocalDateTime deletedAt;
-
     @Enumerated(value = EnumType.STRING)
     @Column(nullable = false)
     private SocialType socialType;
 
     @Builder
-    public User(Long id, String identifier, String nickname, String email, LocalDateTime createdAt, SocialType socialType) {
+    public User(Long id, String identifier, String nickname, String email, SocialType socialType) {
         this.id = id;
         this.identifier = identifier;
         this.nickname = nickname;
         this.email = email;
-        this.createdAt = createdAt;
         this.socialType = socialType;
     }
 }

--- a/src/test/java/weavers/siltarae/mistake/service/MistakeServiceTest.java
+++ b/src/test/java/weavers/siltarae/mistake/service/MistakeServiceTest.java
@@ -15,7 +15,6 @@ import weavers.siltarae.user.domain.SocialType;
 import weavers.siltarae.user.domain.User;
 import weavers.siltarae.user.domain.repository.UserRepository;
 
-import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Optional;
 
@@ -38,14 +37,12 @@ public class MistakeServiceTest {
     User MOCK_USER = User.builder()
             .id(1L)
             .email("siltarae@nn.com")
-            .createdAt(LocalDateTime.now())
             .nickname("실타래")
             .socialType(SocialType.GOOGLE)
             .build();
 
     Tag MOCK_TAG = Tag.builder()
             .id(1L)
-            .createdAt(LocalDateTime.now())
             .name("태그")
             .user(MOCK_USER)
             .build();
@@ -55,7 +52,6 @@ public class MistakeServiceTest {
             .tags(Collections.singletonList(MOCK_TAG))
             .user(MOCK_USER)
             .content("실수 내용 입니다")
-            .createdAt(LocalDateTime.now())
             .build();
 
     @Test

--- a/src/test/java/weavers/siltarae/tag/TagTestFixture.java
+++ b/src/test/java/weavers/siltarae/tag/TagTestFixture.java
@@ -2,15 +2,12 @@ package weavers.siltarae.tag;
 
 import weavers.siltarae.tag.domain.Tag;
 
-import java.time.LocalDateTime;
-
 public class TagTestFixture {
 
     public static Tag COMPANY_TAG() {
         return Tag.builder()
                 .id(1L)
                 .name("회사")
-                .createdAt(LocalDateTime.now())
                 .build();
     }
 
@@ -18,7 +15,6 @@ public class TagTestFixture {
         return Tag.builder()
                 .id(1L)
                 .name("일상")
-                .createdAt(LocalDateTime.now())
                 .build();
     }
 
@@ -26,7 +22,6 @@ public class TagTestFixture {
         Tag deletedTag = Tag.builder()
                             .id(1L)
                             .name("모의고사")
-                            .createdAt(LocalDateTime.of(2018, 3, 15, 23, 2))
                             .build();
 
         deletedTag.delete();

--- a/src/test/java/weavers/siltarae/tag/domain/TagTest.java
+++ b/src/test/java/weavers/siltarae/tag/domain/TagTest.java
@@ -1,0 +1,34 @@
+package weavers.siltarae.tag.domain;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import weavers.siltarae.tag.domain.repository.TagRepository;
+import weavers.siltarae.user.UserTestFixture;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class TagTest {
+
+    @Autowired
+    TagRepository tagRepository;
+
+    @Test
+    void 태그_생성_시_생성일이_자동으로_지정된다() {
+        // given
+        Tag createdTag = Tag.builder()
+                .name("tag")
+                .user(UserTestFixture.USER_KIM())
+                .build();
+
+        // when
+        Tag savedTag = tagRepository.save(createdTag);
+        System.out.println("createdAt: " + savedTag.getCreatedAt());
+
+        // then
+        assertThat(savedTag.getCreatedAt()).isBefore(LocalDateTime.now());
+    }
+}

--- a/src/test/java/weavers/siltarae/tag/service/TagServiceTest.java
+++ b/src/test/java/weavers/siltarae/tag/service/TagServiceTest.java
@@ -12,7 +12,6 @@ import weavers.siltarae.tag.dto.request.TagCreateRequest;
 import weavers.siltarae.tag.dto.response.TagListResponse;
 import weavers.siltarae.user.domain.repository.UserRepository;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -38,11 +37,11 @@ class TagServiceTest {
     @Test
     void 태그_생성_후_tagId를_반환한다() {
         // given
-        final TagCreateRequest tagCreateRequest = new TagCreateRequest(COMPANY_TAG.getName());
+        final TagCreateRequest tagCreateRequest = new TagCreateRequest(COMPANY_TAG().getName());
         given(userRepository.findById(2L))
                 .willReturn(Optional.ofNullable(USER_KIM()));
         given(tagRepository.save(any(Tag.class)))
-                .willReturn(COMPANY_TAG);
+                .willReturn(COMPANY_TAG());
 
         // when
         final Long actualId = tagService.save(2L, tagCreateRequest);
@@ -67,12 +66,6 @@ class TagServiceTest {
         // then
         assertThat(e.getMessage()).isEqualTo("중복된 태그명입니다.");
     }
-
-    static Tag COMPANY_TAG = Tag.builder()
-            .id(1L)
-            .name("회사")
-            .createdAt(LocalDateTime.now())
-            .build();
 
     @Test
     void 사용자의_태그_목록을_조회할_수_있다() {
@@ -101,4 +94,5 @@ class TagServiceTest {
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage("해당하는 태그가 존재하지 않습니다.");
     }
+
 }

--- a/src/test/java/weavers/siltarae/user/UserTestFixture.java
+++ b/src/test/java/weavers/siltarae/user/UserTestFixture.java
@@ -3,15 +3,12 @@ package weavers.siltarae.user;
 import weavers.siltarae.user.domain.SocialType;
 import weavers.siltarae.user.domain.User;
 
-import java.time.LocalDateTime;
-
 public class UserTestFixture {
 
     public static User USER_KIM() {
         return User.builder()
                 .id(1L)
                 .email("siltarae@nn.com")
-                .createdAt(LocalDateTime.now())
                 .nickname("Kim")
                 .socialType(SocialType.GOOGLE)
                 .build();


### PR DESCRIPTION
## 🔥 관련 이슈
close #9 

## ✨ 변경사항
- JPA Auditing을 사용하여 엔티티 저장 시 생성일이 자동 등록되도록 하였습니다.
- BaseEntity 클래스를 생성하였습니다.
  - 생성일, 삭제일, 삭제 메서드, 삭제 여부 반환 메서드를 멤버로 갖고 있습니다. 
  - 기존 엔티티들은 BaseEntity를 상속합니다.

## 📝 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?