### PR TITLE
fix: 로그인 API의 HttpMethod를 구글 명세서에 맞게 Post에서 Get으로 변경

### DIFF
--- a/src/main/java/weavers/siltarae/login/controller/LoginController.java
+++ b/src/main/java/weavers/siltarae/login/controller/LoginController.java
@@ -20,7 +20,7 @@ public class LoginController {
 
     private final LoginService loginService;
 
-    @PostMapping("/login/{socialType}")
+    @GetMapping("/login/{socialType}")
     public ResponseEntity<AccessTokenResponse> login(@PathVariable final String socialType,
                                                      @RequestParam final String code) {
 

--- a/src/main/java/weavers/siltarae/login/domain/TokenProvider.java
+++ b/src/main/java/weavers/siltarae/login/domain/TokenProvider.java
@@ -93,8 +93,9 @@ public class TokenProvider {
         RefreshToken refreshToken = refreshTokenRepository.findById(memberId)
                 .orElseThrow(() -> new RefreshTokenException(ExceptionCode.EXPIRED_REFRESH_TOKEN));
 
-        if(token.equals(refreshToken.getRefreshToken())) return;
-        throw new BadRequestException(ExceptionCode.INVALID_REFRESH_TOKEN);
+        if(!token.equals(refreshToken.getRefreshToken())) {
+            throw new BadRequestException(ExceptionCode.INVALID_REFRESH_TOKEN);
+        }
     }
 
     public Long getMemberIdFromAccessToken(final String accessToken) {


### PR DESCRIPTION
## 🔥 관련 이슈
Issue: #33 

## ✨ 변경사항
- 로그인 API의 HttpMethod를 GET으로 변경

## 📝 작업 유형
- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
