### PR TITLE
feat: [#68]로그아웃 기능 구현

### DIFF
--- a/src/main/java/weavers/siltarae/login/controller/LoginController.java
+++ b/src/main/java/weavers/siltarae/login/controller/LoginController.java
@@ -53,4 +53,12 @@ public class LoginController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(accessTokenResponse);
     }
+
+    @DeleteMapping("/logout")
+    public ResponseEntity<Void> logout(@CookieValue("refresh-token") final String refreshToken) {
+        loginService.logout(refreshToken);
+
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/weavers/siltarae/login/domain/RefreshToken.java
+++ b/src/main/java/weavers/siltarae/login/domain/RefreshToken.java
@@ -12,17 +12,18 @@ import org.springframework.data.redis.core.TimeToLive;
 public class RefreshToken {
 
     @Id
-    private Long memberId;
     private String refreshToken;
+
+    private Long memberId;
 
     @TimeToLive
     @Value("${jwt.refresh-expiration-time}")
     private Long timeToLive;
 
     @Builder
-    public RefreshToken(Long memberId, String refreshToken, Long timeToLive) {
-        this.memberId = memberId;
+    public RefreshToken(String refreshToken, Long memberId, Long timeToLive) {
         this.refreshToken = refreshToken;
+        this.memberId = memberId;
         this.timeToLive = timeToLive;
     }
 }

--- a/src/main/java/weavers/siltarae/login/domain/TokenProvider.java
+++ b/src/main/java/weavers/siltarae/login/domain/TokenProvider.java
@@ -90,7 +90,7 @@ public class TokenProvider {
     }
 
     private void validateRefreshToken(final String token, final Long memberId) {
-        RefreshToken refreshToken = refreshTokenRepository.findById(memberId)
+        RefreshToken refreshToken = refreshTokenRepository.findById(token)
                 .orElseThrow(() -> new RefreshTokenException(ExceptionCode.EXPIRED_REFRESH_TOKEN));
 
         if(token.equals(refreshToken.getRefreshToken())) return;
@@ -114,5 +114,9 @@ public class TokenProvider {
         } catch (JwtException | IllegalArgumentException e) {
             throw new BadRequestException(ExceptionCode.INVALID_ACCESS_TOKEN);
         }
+    }
+
+    public void deleteRefreshToken(final String token) {
+        refreshTokenRepository.deleteById(token);
     }
 }

--- a/src/main/java/weavers/siltarae/login/domain/TokenProvider.java
+++ b/src/main/java/weavers/siltarae/login/domain/TokenProvider.java
@@ -93,7 +93,7 @@ public class TokenProvider {
         RefreshToken refreshToken = refreshTokenRepository.findById(token)
                 .orElseThrow(() -> new RefreshTokenException(ExceptionCode.EXPIRED_REFRESH_TOKEN));
 
-        if(!token.equals(refreshToken.getRefreshToken())) {
+        if(!memberId.equals(refreshToken.getMemberId())) {
             throw new BadRequestException(ExceptionCode.INVALID_REFRESH_TOKEN);
         }
     }

--- a/src/main/java/weavers/siltarae/login/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/weavers/siltarae/login/domain/repository/RefreshTokenRepository.java
@@ -3,5 +3,5 @@ package weavers.siltarae.login.domain.repository;
 import org.springframework.data.repository.CrudRepository;
 import weavers.siltarae.login.domain.RefreshToken;
 
-public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
 }

--- a/src/main/java/weavers/siltarae/login/service/LoginService.java
+++ b/src/main/java/weavers/siltarae/login/service/LoginService.java
@@ -67,4 +67,8 @@ public class LoginService {
                 .build();
         return memberRepository.save(createdMember);
     }
+
+    public void logout(String refreshToken) {
+        tokenProvider.deleteRefreshToken(refreshToken);
+    }
 }

--- a/src/main/java/weavers/siltarae/login/service/LoginService.java
+++ b/src/main/java/weavers/siltarae/login/service/LoginService.java
@@ -39,6 +39,7 @@ public class LoginService {
         final String accessToken = getAccessTokenFromHeader(authorizationHeader);
 
         if(!tokenProvider.isExpiredAccessAndValidRefresh(accessToken, refreshToken)) {
+            logout(refreshToken);
             throw new AuthException(ExceptionCode.FAIL_TO_VALIDATE_TOKEN);
         }
 


### PR DESCRIPTION
## 🔥 관련 이슈
close #68 

## ✨ 변경사항
- 로그아웃 시, 사용자의 리프레시 토큰을 삭제합니다.
- 액세스 토큰은 클라이언트 측에서 삭제합니다.
- 기존 코드 수정: 액세스 토큰 재발급 실패 시, **사용자 로그아웃 처리 후 예외를 발생**시킵니다.

## 📝 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
