### PR TITLE
fix: [#59] 컨트롤러 테스트 오류 수정

### DIFF
--- a/src/main/java/weavers/siltarae/SiltaraeBeApplication.java
+++ b/src/main/java/weavers/siltarae/SiltaraeBeApplication.java
@@ -3,9 +3,7 @@ package weavers.siltarae;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @EnableFeignClients
 @SpringBootApplication
 public class SiltaraeBeApplication {

--- a/src/main/java/weavers/siltarae/global/config/JpaAuditingConfig.java
+++ b/src/main/java/weavers/siltarae/global/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package weavers.siltarae.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/test/java/weavers/siltarae/tag/TagTestFixture.java
+++ b/src/test/java/weavers/siltarae/tag/TagTestFixture.java
@@ -26,6 +26,7 @@ public class TagTestFixture {
         Tag deletedTag = Tag.builder()
                             .id(1L)
                             .name("모의고사")
+                            .mistakes(List.of())
                             .build();
 
         deletedTag.delete();

--- a/src/test/java/weavers/siltarae/tag/TagTestFixture.java
+++ b/src/test/java/weavers/siltarae/tag/TagTestFixture.java
@@ -2,12 +2,15 @@ package weavers.siltarae.tag;
 
 import weavers.siltarae.tag.domain.Tag;
 
+import java.util.List;
+
 public class TagTestFixture {
 
     public static Tag COMPANY_TAG() {
         return Tag.builder()
                 .id(1L)
                 .name("회사")
+                .mistakes(List.of())
                 .build();
     }
 
@@ -15,6 +18,7 @@ public class TagTestFixture {
         return Tag.builder()
                 .id(1L)
                 .name("일상")
+                .mistakes(List.of())
                 .build();
     }
 

--- a/src/test/java/weavers/siltarae/tag/controller/TagControllerTest.java
+++ b/src/test/java/weavers/siltarae/tag/controller/TagControllerTest.java
@@ -77,7 +77,7 @@ class TagControllerTest {
 
         // then
         resultActions.andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("태그명에는 한글, 영어, 숫자, _만 사용 가능합니다."));
+                .andExpect(jsonPath("$.message").value("태그명에는 한글, 영어, 숫자, 연속 1개 이하의 _만 사용 가능합니다."));
     }
 
     @Test


### PR DESCRIPTION
## 🔥 관련 이슈
close #59 

## ✨ 변경사항
- JpaAuditing을 설정 클래스로 분리하였습니다.
- TagTestFixture의 mistakes 필드에 값을 넣어주었습니다.
- 특수문자가 포함된 태그를 등록하는 테스트의 예상 메세지를 수정하였습니다.

## 📝 작업 유형
- [ ] 신규 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
