### PR TITLE
fix:[#52] 태그 조회 시 빈 태그 리스트 반환 

### DIFF
--- a/src/main/java/weavers/siltarae/tag/domain/repository/TagRepository.java
+++ b/src/main/java/weavers/siltarae/tag/domain/repository/TagRepository.java
@@ -8,6 +8,6 @@ import java.util.List;
 public interface TagRepository extends JpaRepository<Tag, Long> {
     boolean existsByMember_IdAndName(Long memberId, String name);
 
-    List<Tag> findAllByMember_IdAndDeletedAtIsNotNull(Long userId);
+    List<Tag> findAllByMember_IdAndDeletedAtIsNull(Long userId);
 }
 

--- a/src/main/java/weavers/siltarae/tag/service/TagService.java
+++ b/src/main/java/weavers/siltarae/tag/service/TagService.java
@@ -52,7 +52,7 @@ public class TagService {
 
     @Transactional(readOnly = true)
     public TagListResponse getTagList(final Long memberId) {
-        List<Tag> tagList = tagRepository.findAllByMember_IdAndDeletedAtIsNotNull(memberId);
+        List<Tag> tagList = tagRepository.findAllByMember_IdAndDeletedAtIsNull(memberId);
 
         return TagListResponse.from(tagList);
     }

--- a/src/test/java/weavers/siltarae/tag/service/TagServiceTest.java
+++ b/src/test/java/weavers/siltarae/tag/service/TagServiceTest.java
@@ -70,7 +70,7 @@ class TagServiceTest {
     @Test
     void 사용자의_태그_목록을_조회할_수_있다() {
         // given
-        given(tagRepository.findAllByMember_IdAndDeletedAtIsNotNull(1L))
+        given(tagRepository.findAllByMember_IdAndDeletedAtIsNull(1L))
                 .willReturn(List.of(COMPANY_TAG(), DAILY_TAG()));
 
         // when


### PR DESCRIPTION
## 🔥 관련 이슈
Issue: #52 

## ✨ 변경사항
- 태그 조회 시 빈 태그 리스트 반환
- deleteAtIsNotNull 을 deleteAtIsNull 로 수정

## 📝 작업 유형
- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?

