### PR TITLE
refactor:[#70] 태그 조회와 실수 조회 Response Dto 분리

### DIFF
--- a/src/main/java/weavers/siltarae/mistake/dto/response/MistakeResponse.java
+++ b/src/main/java/weavers/siltarae/mistake/dto/response/MistakeResponse.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import weavers.siltarae.mistake.domain.Mistake;
-import weavers.siltarae.tag.dto.response.TagResponse;
+import weavers.siltarae.tag.dto.response.MistakeTagResponse;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -17,14 +17,14 @@ import static lombok.AccessLevel.PROTECTED;
 public class MistakeResponse {
     private Long id;
     private String content;
-    private List<TagResponse> tags;
+    private List<MistakeTagResponse> tags;
     private Integer commentCount;
     private Integer likeCount;
     private Long memberId;
     private String memberName;
 
     @Builder
-    public MistakeResponse(Long id, String content, List<TagResponse> tags, Integer commentCount, Integer likeCount, Long memberId, String memberName) {
+    public MistakeResponse(Long id, String content, List<MistakeTagResponse> tags, Integer commentCount, Integer likeCount, Long memberId, String memberName) {
         this.id = id;
         this.content = content;
         this.tags = tags;
@@ -38,8 +38,8 @@ public class MistakeResponse {
     private static final Integer TEST_LIKE_COUNT = 11;
 
     public static MistakeResponse from(Mistake mistake) {
-        List<TagResponse> tag = mistake.getTags().stream().map(
-                TagResponse::from
+        List<MistakeTagResponse> tag = mistake.getTags().stream().map(
+                MistakeTagResponse::from
         ).collect(Collectors.toList());
 
         return MistakeResponse.builder()

--- a/src/main/java/weavers/siltarae/tag/dto/response/MistakeTagResponse.java
+++ b/src/main/java/weavers/siltarae/tag/dto/response/MistakeTagResponse.java
@@ -1,0 +1,29 @@
+package weavers.siltarae.tag.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import weavers.siltarae.tag.domain.Tag;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class MistakeTagResponse {
+    private Long id;
+    private String name;
+
+    @Builder
+    public MistakeTagResponse(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public static MistakeTagResponse from(Tag tag) {
+        return MistakeTagResponse.builder()
+                .id(tag.getId())
+                .name(tag.getName())
+                .build();
+    }
+
+}


### PR DESCRIPTION
## 🔥 관련 이슈
Issue: #70 

## ✨ 변경사항
- 태그 조회와 실수 조회 Response Dto 분리

## 📝 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
