### PR TITLE
feat: [#34]Authorization 헤더 추출 어노테이션 구현

### DIFF
--- a/src/main/java/weavers/siltarae/global/exception/ExceptionCode.java
+++ b/src/main/java/weavers/siltarae/global/exception/ExceptionCode.java
@@ -20,6 +20,7 @@ public enum ExceptionCode {
 
     NOT_SUPPORTED_AUTH_SERVICE(5001, "지원하는 소셜 로그인 서비스가 아닙니다."),
     INVALID_AUTHORIZATION_CODE(5002, "인증 코드가 유효하지 않습니다."),
+    AVAILABLE_AFTER_LOGIN(5003, "로그인 후 이용 가능합니다."),
     EXPIRED_ACCESS_TOKEN(5101, "만료된 액세스 토큰입니다."),
     EXPIRED_REFRESH_TOKEN(5102, "만료된 리프레시 토큰입니다."),
     INVALID_ACCESS_TOKEN(5103, "유효하지 않은 액세스 토큰입니다."),

--- a/src/main/java/weavers/siltarae/login/AccessTokenExtractor.java
+++ b/src/main/java/weavers/siltarae/login/AccessTokenExtractor.java
@@ -1,0 +1,20 @@
+package weavers.siltarae.login;
+
+import org.springframework.stereotype.Component;
+import weavers.siltarae.global.exception.AuthException;
+import weavers.siltarae.global.exception.ExceptionCode;
+
+@Component
+public class AccessTokenExtractor {
+
+    private final String BEARER_TYPE = "Bearer";
+
+    public String extractAccessToken(String authorizationHeader) {
+        if(authorizationHeader==null || !authorizationHeader.startsWith(BEARER_TYPE)) {
+            throw new AuthException(ExceptionCode.AVAILABLE_AFTER_LOGIN);
+        }
+        return authorizationHeader.substring(BEARER_TYPE.length()).trim();
+    }
+
+
+}

--- a/src/main/java/weavers/siltarae/login/Auth.java
+++ b/src/main/java/weavers/siltarae/login/Auth.java
@@ -1,0 +1,11 @@
+package weavers.siltarae.login;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Auth {
+}

--- a/src/main/java/weavers/siltarae/login/AuthArgumentResolver.java
+++ b/src/main/java/weavers/siltarae/login/AuthArgumentResolver.java
@@ -1,0 +1,37 @@
+package weavers.siltarae.login;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import weavers.siltarae.login.domain.TokenProvider;
+
+import static org.springframework.http.HttpHeaders.*;
+
+@Component
+@RequiredArgsConstructor
+public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final AccessTokenExtractor accessTokenExtractor;
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasAuthAnnotation = parameter.hasParameterAnnotation(Auth.class);
+        boolean hasLongType = Long.class.isAssignableFrom(parameter.getParameterType());
+
+        return hasAuthAnnotation && hasLongType;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        String accessToken = accessTokenExtractor.extractAccessToken(request.getHeader(AUTHORIZATION));
+
+        return tokenProvider.getMemberIdFromAccessToken(accessToken);
+    }
+}


### PR DESCRIPTION
## 🔥 관련 이슈
close #34 

## ✨ 변경사항
- 파라미터 어노테이션 **`@Auth`를 추가**하였습니다.
- 컨트롤러 파라미터로 `@Auth` 어노테이션이 붙은 Long 타입의 변수가 있으면, Authorization 헤더에서 memberId를 추출하여 파라미터에 넣어주는 **ArgumentResolver를 추가**하였습니다.
- 헤더에서 액세스 토큰 값을 추출하는 것이 LoginService의 역할과 맞지 않다고 생각하여 **AccessTokenExtractor로 분리**하였습니다.

## 👀 리뷰 포인트
- 헤더에서 액세스 토큰을 추출하는 부분을 AccessTokenExtractor로 분리하는 것이 적절한 선택이었을까요?
- ArgumentResolver에서 별도의 Exception을 던지고 있지 않습니다. 
`getNativeRequest()`는 스펙 상 Null을 리턴하지 않으며, 그 외에는 파라미터로 잘못된 값이 들어온 경우 해당 메서드에서 예외를 던지기 때문입니다. 이 부분에 대해 예외처리가 적절히 이루어졌는지, 혹시 빼먹은 부분은 없는지 한번 더 확인주시면 감사하겠습니다🙌

## 📝 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?