### PR TITLE
feat: [#85]회원정보 추출 어노테이션 적용

### DIFF
--- a/src/main/java/weavers/siltarae/comment/controller/CommentController.java
+++ b/src/main/java/weavers/siltarae/comment/controller/CommentController.java
@@ -9,6 +9,7 @@ import weavers.siltarae.comment.dto.request.CommentCreateRequest;
 import weavers.siltarae.comment.dto.request.CommentListRequest;
 import weavers.siltarae.comment.dto.response.CommentListResponse;
 import weavers.siltarae.comment.service.CommentService;
+import weavers.siltarae.login.Auth;
 
 @Tag(name = "[댓글] 댓글 Controller")
 @RestController
@@ -17,7 +18,6 @@ import weavers.siltarae.comment.service.CommentService;
 public class CommentController {
 
     private final CommentService commentService;
-    private static final Long TEST_USER_ID = 1L;
 
     @GetMapping
     public ResponseEntity<CommentListResponse> getComments(
@@ -28,16 +28,18 @@ public class CommentController {
 
     @PostMapping
     public ResponseEntity<Void> createComment(
+            @Auth Long memberId,
             @RequestBody @Valid CommentCreateRequest request) {
-        commentService.save(request, TEST_USER_ID);
+        commentService.save(request, memberId);
 
         return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping("/{commentId}")
     public ResponseEntity<Void> deleteComment(
+            @Auth Long memberId,
             @PathVariable("commentId") Long commentId) {
-        commentService.delete(commentId, TEST_USER_ID);
+        commentService.delete(commentId, memberId);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/weavers/siltarae/like/controller/LikeController.java
+++ b/src/main/java/weavers/siltarae/like/controller/LikeController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import weavers.siltarae.like.service.LikeService;
+import weavers.siltarae.login.Auth;
 
 @Tag(name = "[좋아요] 좋아요 Controller")
 @RestController
@@ -12,13 +13,13 @@ import weavers.siltarae.like.service.LikeService;
 @RequestMapping("/api/v1/like")
 public class LikeController {
 
-    private static final Long TEST_USER_ID = 1L;
     private final LikeService likeService;
 
     @PostMapping
     public ResponseEntity<Void> addLike(
+            @Auth Long memberId,
             @RequestParam("mistakeId") Long mistakeId) {
-        likeService.like(TEST_USER_ID, mistakeId);
+        likeService.like(memberId, mistakeId);
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/weavers/siltarae/login/controller/LoginController.java
+++ b/src/main/java/weavers/siltarae/login/controller/LoginController.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import weavers.siltarae.login.Auth;
 import weavers.siltarae.login.dto.response.AccessTokenResponse;
 import weavers.siltarae.login.dto.response.TokenPair;
 import weavers.siltarae.login.service.LoginService;
@@ -55,7 +56,9 @@ public class LoginController {
     }
 
     @DeleteMapping("/logout")
-    public ResponseEntity<Void> logout(@CookieValue("refresh-token") final String refreshToken) {
+    public ResponseEntity<Void> logout(
+            @Auth final Long memberId,
+            @CookieValue("refresh-token") final String refreshToken) {
         loginService.logout(refreshToken);
 
         return ResponseEntity.noContent().build();

--- a/src/main/java/weavers/siltarae/mistake/controller/MistakeController.java
+++ b/src/main/java/weavers/siltarae/mistake/controller/MistakeController.java
@@ -3,10 +3,10 @@ package weavers.siltarae.mistake.controller;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import weavers.siltarae.global.dto.request.PageRequest;
+import weavers.siltarae.login.Auth;
 import weavers.siltarae.mistake.dto.request.MistakeCreateRequest;
 import weavers.siltarae.mistake.dto.response.MistakeListResponse;
 import weavers.siltarae.mistake.dto.response.MistakeResponse;
@@ -22,31 +22,32 @@ import java.util.List;
 public class MistakeController {
     private final MistakeService mistakeService;
 
-    private static final Long TEST_USER_ID = 1L;
-
-    @PostMapping("")
+    @PostMapping
     public ResponseEntity<Void> createMistake(
+            @Auth Long memberId,
             @RequestBody @Valid MistakeCreateRequest request) {
-        Long mistakeId = mistakeService.save(request, TEST_USER_ID);
+        Long mistakeId = mistakeService.save(request, memberId);
 
         return ResponseEntity.created(URI.create("mistakes/" + mistakeId)).build();
     }
 
     @GetMapping
-    public ResponseEntity<MistakeListResponse> getMistakes(PageRequest request) {
-        return ResponseEntity.ok(mistakeService.getMistakeList(TEST_USER_ID, request.toPageable()));
+    public ResponseEntity<MistakeListResponse> getMistakes(@Auth Long memberId, PageRequest request) {
+        return ResponseEntity.ok(mistakeService.getMistakeList(memberId, request.toPageable()));
     }
 
     @GetMapping("/{mistakeId}")
     public ResponseEntity<MistakeResponse> getMistake(
+            @Auth Long memberId,
             @PathVariable("mistakeId") Long mistakeId) {
-        return ResponseEntity.ok(mistakeService.getMistake(TEST_USER_ID, mistakeId));
+        return ResponseEntity.ok(mistakeService.getMistake(memberId, mistakeId));
     }
 
     @PostMapping("/delete")
     public ResponseEntity<Void> deleteMistake(
+            @Auth Long memberId,
             @RequestBody List<Long> ids) {
-        mistakeService.deleteMistake(TEST_USER_ID, ids);
+        mistakeService.deleteMistake(memberId, ids);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/weavers/siltarae/tag/controller/TagController.java
+++ b/src/main/java/weavers/siltarae/tag/controller/TagController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import weavers.siltarae.login.Auth;
 import weavers.siltarae.tag.dto.request.TagCreateRequest;
 import weavers.siltarae.tag.dto.response.TagListResponse;
 import weavers.siltarae.tag.service.TagService;
@@ -15,20 +16,20 @@ import java.util.List;
 @RequiredArgsConstructor
 public class TagController {
 
-    private final Long TEMP_USER_ID = 1L;
-
     private final TagService tagService;
 
     @PostMapping
-    public ResponseEntity<Void> createTag(@RequestBody @Valid final TagCreateRequest request) {
-        tagService.save(TEMP_USER_ID, request);
+    public ResponseEntity<Void> createTag(
+            @Auth Long memberId,
+            @RequestBody @Valid final TagCreateRequest request) {
+        tagService.save(memberId, request);
 
         return ResponseEntity.noContent().build();
     }
 
     @GetMapping
-    public ResponseEntity<TagListResponse> getTagList() {
-        TagListResponse tagListResponse = tagService.getTagList(TEMP_USER_ID);
+    public ResponseEntity<TagListResponse> getTagList(@Auth Long memberId) {
+        TagListResponse tagListResponse = tagService.getTagList(memberId);
 
         return ResponseEntity.ok(tagListResponse);
     }


### PR DESCRIPTION
## 🔥 관련 이슈
close #85 

## ✨ 변경사항
- 컨트롤러의 회원 전용 기능 메서드에 Auth Long memberId 파라미터를 추가했습니다.
- Auth 어노테이션은 액세스 토큰 검증의 역할도 겸하고 있기 때문에, memberId를 사용하지 않더라도 회원 전용 기능이면 Auth 어노테이션을 사용했습니다.

## 📝 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
