### PR TITLE
refactor: [#93]로그인 API를 POST로 변경

### DIFF
--- a/src/main/java/weavers/siltarae/login/controller/LoginController.java
+++ b/src/main/java/weavers/siltarae/login/controller/LoginController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import weavers.siltarae.login.Auth;
+import weavers.siltarae.login.dto.request.LoginRequest;
 import weavers.siltarae.login.dto.response.AccessTokenResponse;
 import weavers.siltarae.login.dto.response.TokenPair;
 import weavers.siltarae.login.service.LoginService;
@@ -21,11 +22,11 @@ public class LoginController {
 
     private final LoginService loginService;
 
-    @GetMapping("/login/{socialType}")
+    @PostMapping("/login/{socialType}")
     public ResponseEntity<AccessTokenResponse> login(@PathVariable final String socialType,
-                                                     @RequestParam final String code) {
+                                                     @RequestBody final LoginRequest request) {
 
-        final TokenPair tokenPair = loginService.login(socialType, code);
+        final TokenPair tokenPair = loginService.login(socialType, request.getAuthCode());
 
         ResponseCookie cookie = ResponseCookie.from("refresh-token", tokenPair.getRefreshToken())
                 .maxAge(tokenPair.getRefreshTokenExpirationTime())


### PR DESCRIPTION
## 🔥 관련 이슈
close #93 

## ✨ 변경사항
- 로그인 API를 POST로 변경했어요.
- 구글의 인증 코드를 쿼리가 아닌 바디에서 받아오기로 했어요.

## 📝 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?