### PR TITLE
feat: [#87]회원 탈퇴 기능 추가

### DIFF
--- a/src/main/java/weavers/siltarae/member/controller/MemberController.java
+++ b/src/main/java/weavers/siltarae/member/controller/MemberController.java
@@ -1,0 +1,25 @@
+package weavers.siltarae.member.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import weavers.siltarae.login.Auth;
+import weavers.siltarae.member.service.MemberService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/mypage")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @DeleteMapping
+    public ResponseEntity<Void> deleteMember(@Auth Long memberId) {
+        memberService.deleteMember(memberId);
+
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/src/main/java/weavers/siltarae/member/domain/Member.java
+++ b/src/main/java/weavers/siltarae/member/domain/Member.java
@@ -13,22 +13,33 @@ import weavers.siltarae.global.BaseEntity;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
 
+    private static final String DELETED_MEMBER_NICKNAME = "탈퇴회원";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column
     private String identifier;
 
     @Column(nullable = false, length = 10)
     private String nickname;
 
-    @Column(nullable = false)
+    @Column
     private String email;
 
     @Enumerated(value = EnumType.STRING)
-    @Column(nullable = false)
+    @Column
     private SocialType socialType;
+
+    @Override
+    public void delete() {
+        super.delete();
+
+        this.identifier = null;
+        this.nickname = DELETED_MEMBER_NICKNAME;
+        this.email = null;
+    }
 
     @Builder
     public Member(Long id, String identifier, String nickname, String email, SocialType socialType) {

--- a/src/main/java/weavers/siltarae/member/service/MemberService.java
+++ b/src/main/java/weavers/siltarae/member/service/MemberService.java
@@ -1,0 +1,25 @@
+package weavers.siltarae.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import weavers.siltarae.global.exception.BadRequestException;
+import weavers.siltarae.member.domain.Member;
+import weavers.siltarae.member.domain.repository.MemberRepository;
+
+import static weavers.siltarae.global.exception.ExceptionCode.*;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public void deleteMember(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BadRequestException(NOT_FOUND_MEMBER));
+
+        member.delete();
+    }
+}


### PR DESCRIPTION
## 🔥 관련 이슈
close #87 

## ✨ 변경사항
- 회원 탈퇴 기능이 추가되었어요.
- 회원 탈퇴 시, 회원의 실수와 태그는 그대로 남아요.
- 탈퇴된 회원의 소셜 식별자, 소셜 타입, 이메일은 탈퇴 즉시 파기되고, 닉네임은 `탈퇴회원`으로 변경돼요.

## 📝 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
