### PR TITLE
feat: [#106]회원 탈퇴 시 토큰 삭제 로직 추가

### DIFF
--- a/src/main/java/weavers/siltarae/member/controller/MemberController.java
+++ b/src/main/java/weavers/siltarae/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package weavers.siltarae.member.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,8 +17,10 @@ public class MemberController {
     private final MemberService memberService;
 
     @DeleteMapping
-    public ResponseEntity<Void> deleteMember(@Auth Long memberId) {
-        memberService.deleteMember(memberId);
+    public ResponseEntity<Void> deleteMember(
+            @Auth Long memberId,
+            @CookieValue("refresh-token") final String refreshToken) {
+        memberService.deleteMember(memberId, refreshToken);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/weavers/siltarae/member/domain/repository/MemberRepository.java
+++ b/src/main/java/weavers/siltarae/member/domain/repository/MemberRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByIdentifier(String identifier);
+    Optional<Member> findByIdAndDeletedAtIsNull(Long memberId);
 }

--- a/src/main/java/weavers/siltarae/member/service/MemberService.java
+++ b/src/main/java/weavers/siltarae/member/service/MemberService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import weavers.siltarae.global.exception.BadRequestException;
+import weavers.siltarae.login.domain.TokenProvider;
 import weavers.siltarae.member.domain.Member;
 import weavers.siltarae.member.domain.repository.MemberRepository;
 
@@ -15,11 +16,13 @@ import static weavers.siltarae.global.exception.ExceptionCode.*;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final TokenProvider tokenProvider;
 
-    public void deleteMember(Long memberId) {
-        Member member = memberRepository.findById(memberId)
+    public void deleteMember(Long memberId, String refreshToken) {
+        Member member = memberRepository.findByIdAndDeletedAtIsNull(memberId)
                 .orElseThrow(() -> new BadRequestException(NOT_FOUND_MEMBER));
-
         member.delete();
+
+        tokenProvider.deleteRefreshToken(refreshToken);
     }
 }


### PR DESCRIPTION
## 🔥 관련 이슈
close #106 

## ✨ 변경사항
- 회원을 조회할 때, 탈퇴 회원 여부를 검사하도록 만들었어요.
- 회원 탈퇴 시, 리프레시 토큰을 삭제하는 로직을 추가했어요.

## 📝 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?