### PR TITLE
fix: [#110] 실수 조회 시 tag 가 null 이 아닌 비어있다면 오류 발생

### DIFF
--- a/src/main/java/weavers/siltarae/mistake/service/MistakeService.java
+++ b/src/main/java/weavers/siltarae/mistake/service/MistakeService.java
@@ -53,7 +53,7 @@ public class MistakeService {
     }
 
     private List<Long> getTagIdsFromRequest(MistakeListRequest request) {
-        if (request.getTag() != null) {
+        if (!request.getTag().isEmpty()) {
             return getLongs(request);
         }
 


### PR DESCRIPTION
## 🔥 관련 이슈
Issue: #110 

## ✨ 변경사항
- tag 가 null 이 아니라 비어있어도 오류가 발생하지않고 response 값이 정상적으로 나올 수 있게끔 변경

## 📝 작업 유형
- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?

