### PR TITLE
feat: [#109] 회원정보 조회 기능 구현

### DIFF
--- a/src/main/java/weavers/siltarae/member/controller/MemberController.java
+++ b/src/main/java/weavers/siltarae/member/controller/MemberController.java
@@ -5,8 +5,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import weavers.siltarae.login.Auth;
-import weavers.siltarae.member.dto.MemberResponse;
-import weavers.siltarae.member.dto.MemberUpdateRequest;
+import weavers.siltarae.member.dto.response.MemberInfoResponse;
+import weavers.siltarae.member.dto.response.MemberNicknameResponse;
+import weavers.siltarae.member.dto.request.MemberUpdateRequest;
 import weavers.siltarae.member.service.MemberService;
 
 import java.net.URI;
@@ -18,6 +19,13 @@ public class MemberController {
 
     private final MemberService memberService;
 
+    @GetMapping
+    public ResponseEntity<MemberInfoResponse> getMemberInfo(@Auth Long memberId) {
+        MemberInfoResponse response = memberService.getMemberInfo(memberId);
+
+        return ResponseEntity.ok(response);
+    }
+
     @PostMapping("/image")
     public ResponseEntity<Void> uploadMemberImage(@Auth Long memberId, @RequestPart MultipartFile file) {
         memberService.deleteMemberImage(memberId);
@@ -27,8 +35,8 @@ public class MemberController {
     }
 
     @PutMapping
-    public ResponseEntity<MemberResponse> updateMemberNickname(@Auth Long memberId, @RequestBody MemberUpdateRequest request) {
-        MemberResponse response = memberService.changeMemberNickname(memberId, request);
+    public ResponseEntity<MemberNicknameResponse> updateMemberNickname(@Auth Long memberId, @RequestBody MemberUpdateRequest request) {
+        MemberNicknameResponse response = memberService.changeMemberNickname(memberId, request);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/weavers/siltarae/member/dto/request/MemberUpdateRequest.java
+++ b/src/main/java/weavers/siltarae/member/dto/request/MemberUpdateRequest.java
@@ -1,4 +1,4 @@
-package weavers.siltarae.member.dto;
+package weavers.siltarae.member.dto.request;
 
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;

--- a/src/main/java/weavers/siltarae/member/dto/response/MemberInfoResponse.java
+++ b/src/main/java/weavers/siltarae/member/dto/response/MemberInfoResponse.java
@@ -1,0 +1,28 @@
+package weavers.siltarae.member.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import weavers.siltarae.member.domain.Member;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberInfoResponse {
+
+    private String nickname;
+    private String imageUrl;
+
+    @Builder
+    public MemberInfoResponse(String nickname, String imageUrl) {
+        this.nickname = nickname;
+        this.imageUrl = imageUrl;
+    }
+
+    public static MemberInfoResponse from(Member member) {
+        return MemberInfoResponse.builder()
+                .nickname(member.getNickname())
+                .imageUrl(member.getImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/weavers/siltarae/member/dto/response/MemberNicknameResponse.java
+++ b/src/main/java/weavers/siltarae/member/dto/response/MemberNicknameResponse.java
@@ -1,4 +1,4 @@
-package weavers.siltarae.member.dto;
+package weavers.siltarae.member.dto.response;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -8,17 +8,17 @@ import weavers.siltarae.member.domain.Member;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MemberResponse {
+public class MemberNicknameResponse {
 
     private String nickname;
 
     @Builder
-    public MemberResponse(String nickname) {
+    public MemberNicknameResponse(String nickname) {
         this.nickname = nickname;
     }
 
-    public static MemberResponse from(Member member) {
-        return MemberResponse.builder()
+    public static MemberNicknameResponse from(Member member) {
+        return MemberNicknameResponse.builder()
                 .nickname(member.getNickname())
                 .build();
     }

--- a/src/main/java/weavers/siltarae/member/service/MemberService.java
+++ b/src/main/java/weavers/siltarae/member/service/MemberService.java
@@ -11,8 +11,9 @@ import weavers.siltarae.global.image.domain.Image;
 import weavers.siltarae.login.domain.TokenProvider;
 import weavers.siltarae.member.domain.Member;
 import weavers.siltarae.member.domain.repository.MemberRepository;
-import weavers.siltarae.member.dto.MemberResponse;
-import weavers.siltarae.member.dto.MemberUpdateRequest;
+import weavers.siltarae.member.dto.response.MemberInfoResponse;
+import weavers.siltarae.member.dto.response.MemberNicknameResponse;
+import weavers.siltarae.member.dto.request.MemberUpdateRequest;
 
 import static weavers.siltarae.global.exception.ExceptionCode.*;
 
@@ -27,6 +28,13 @@ public class MemberService {
 
     @Value("${cloud.aws.s3.folder.member}")
     private String folder;
+
+    public MemberInfoResponse getMemberInfo(Long memberId) {
+        Member member = memberRepository.findByIdAndDeletedAtIsNull(memberId)
+                .orElseThrow(() -> new BadRequestException(NOT_FOUND_MEMBER));
+
+        return MemberInfoResponse.from(member);
+    }
 
     public String uploadMemberImage(Long memberId, MultipartFile file) {
         Image image = new Image(file);
@@ -48,13 +56,13 @@ public class MemberService {
         imageUtil.deleteImage(folder, member.getImageName());
     }
 
-    public MemberResponse changeMemberNickname(Long memberId, MemberUpdateRequest request) {
+    public MemberNicknameResponse changeMemberNickname(Long memberId, MemberUpdateRequest request) {
         Member member = memberRepository.findByIdAndDeletedAtIsNull(memberId)
                 .orElseThrow(() -> new BadRequestException(NOT_FOUND_MEMBER));
 
         member.updateNickname(request.getNickname());
 
-        return MemberResponse.from(member);
+        return MemberNicknameResponse.from(member);
     }
 
     public void deleteMember(Long memberId, String refreshToken) {


### PR DESCRIPTION
## 🔥 관련 이슈
close #109 

## ✨ 변경사항
- 회원 정보 조회 기능을 구현했어요.
- RequestDTO와 ResponseDTO의 패키지를 분리했어요.
- 회원 정보에는 닉네임과 프로필 이미지 url이 담겨있어요.

## 📝 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
