### PR TITLE
refactor: [#116]태그 등록 시 태그정보 반환

### DIFF
--- a/src/main/java/weavers/siltarae/tag/controller/TagController.java
+++ b/src/main/java/weavers/siltarae/tag/controller/TagController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.*;
 import weavers.siltarae.login.Auth;
 import weavers.siltarae.tag.dto.request.TagCreateRequest;
 import weavers.siltarae.tag.dto.response.TagListResponse;
+import weavers.siltarae.tag.dto.response.TagResponse;
 import weavers.siltarae.tag.service.TagService;
 
 import java.util.List;
@@ -19,12 +20,12 @@ public class TagController {
     private final TagService tagService;
 
     @PostMapping
-    public ResponseEntity<Void> createTag(
+    public ResponseEntity<TagResponse> createTag(
             @Auth Long memberId,
             @RequestBody @Valid final TagCreateRequest request) {
-        tagService.save(memberId, request);
+        TagResponse response = tagService.save(memberId, request);
 
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping

--- a/src/main/java/weavers/siltarae/tag/service/TagService.java
+++ b/src/main/java/weavers/siltarae/tag/service/TagService.java
@@ -11,6 +11,7 @@ import weavers.siltarae.tag.dto.request.TagCreateRequest;
 import weavers.siltarae.tag.dto.response.TagListResponse;
 import weavers.siltarae.member.domain.Member;
 import weavers.siltarae.member.domain.repository.MemberRepository;
+import weavers.siltarae.tag.dto.response.TagResponse;
 
 import java.util.List;
 
@@ -26,7 +27,7 @@ public class TagService {
 
     private final MemberRepository memberRepository;
 
-    public Long save(final Long memberId, final TagCreateRequest tagCreateRequest) {
+    public TagResponse save(final Long memberId, final TagCreateRequest tagCreateRequest) {
         log.info("============= memberId : {} =============", memberId);
         List<Member> allMember = memberRepository.findAll();
         allMember.forEach(
@@ -47,7 +48,7 @@ public class TagService {
 
         Tag tag = tagRepository.save(createdTag);
 
-        return tag.getId();
+        return TagResponse.from(tag);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/weavers/siltarae/tag/service/TagService.java
+++ b/src/main/java/weavers/siltarae/tag/service/TagService.java
@@ -1,7 +1,6 @@
 package weavers.siltarae.tag.service;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import weavers.siltarae.global.exception.BadRequestException;
@@ -20,7 +19,6 @@ import static weavers.siltarae.global.exception.ExceptionCode.*;
 @Service
 @RequiredArgsConstructor
 @Transactional
-@Slf4j
 public class TagService {
 
     private final TagRepository tagRepository;
@@ -28,12 +26,6 @@ public class TagService {
     private final MemberRepository memberRepository;
 
     public TagResponse save(final Long memberId, final TagCreateRequest tagCreateRequest) {
-        log.info("============= memberId : {} =============", memberId);
-        List<Member> allMember = memberRepository.findAll();
-        allMember.forEach(
-                member -> log.info("============= memberId : {} =============", member.getId())
-        );
-
         final Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BadRequestException(NOT_FOUND_MEMBER));
 


### PR DESCRIPTION
## 🔥 관련 이슈
close: #116 

## ✨ 변경사항
- 태그 등록 API의 응답코드를 204에서 200으로 변경했어요.
- ResponseBody에는 TagResponse(태그 아이디, 태그명, 실수 개수)가 들어있어요.

## 📝 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
