### PR TITLE
fix: [#120]액세스 토큰 추출 로그 추가

### DIFF
--- a/src/main/java/weavers/siltarae/login/AccessTokenExtractor.java
+++ b/src/main/java/weavers/siltarae/login/AccessTokenExtractor.java
@@ -1,9 +1,11 @@
 package weavers.siltarae.login;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import weavers.siltarae.global.exception.AuthException;
 import weavers.siltarae.global.exception.ExceptionCode;
 
+@Slf4j
 @Component
 public class AccessTokenExtractor {
 
@@ -11,6 +13,7 @@ public class AccessTokenExtractor {
 
     public String extractAccessToken(String authorizationHeader) {
         if(authorizationHeader==null || !authorizationHeader.startsWith(BEARER_TYPE)) {
+            log.info("=========== authorization header = {} ==========", authorizationHeader);
             throw new AuthException(ExceptionCode.AVAILABLE_AFTER_LOGIN);
         }
         return authorizationHeader.substring(BEARER_TYPE.length()).trim();


### PR DESCRIPTION
## 🔥 관련 이슈
#120 

## ✨ 변경사항
- 디버깅을 위해 액세스 토큰 추출 시, Authorization Header의 값을 로그로 찍어봤어요.

## 📝 작업 유형
- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
