### PR TITLE
refactor: [#117] 실수 조회 시 회원의 정보 포함하여 반환

### DIFF
--- a/src/main/java/weavers/siltarae/mistake/dto/response/MistakeResponse.java
+++ b/src/main/java/weavers/siltarae/mistake/dto/response/MistakeResponse.java
@@ -21,10 +21,10 @@ public class MistakeResponse {
     private Integer likeCount;
     private Long memberId;
     private String memberName;
-    private String memberImage;
+    private String memberImageUrl;
 
     @Builder
-    public MistakeResponse(Long id, String content, List<MistakeTagResponse> tags, Integer commentCount, Integer likeCount, Long memberId, String memberName, String memberImage) {
+    public MistakeResponse(Long id, String content, List<MistakeTagResponse> tags, Integer commentCount, Integer likeCount, Long memberId, String memberName, String memberImageUrl) {
         this.id = id;
         this.content = content;
         this.tags = tags;
@@ -32,7 +32,7 @@ public class MistakeResponse {
         this.likeCount = likeCount;
         this.memberId = memberId;
         this.memberName = memberName;
-        this.memberImage = memberImage;
+        this.memberImageUrl = memberImageUrl;
     }
 
     public static MistakeResponse from(Mistake mistake) {
@@ -48,7 +48,7 @@ public class MistakeResponse {
                 .tags(tag)
                 .memberId(mistake.getMember().getId())
                 .memberName(mistake.getMember().getNickname())
-                .memberImage(mistake.getMember().getImageName())
+                .memberImageUrl(mistake.getMember().getImageUrl())
                 .build();
     }
 

--- a/src/main/java/weavers/siltarae/mistake/dto/response/MistakeResponse.java
+++ b/src/main/java/weavers/siltarae/mistake/dto/response/MistakeResponse.java
@@ -19,14 +19,20 @@ public class MistakeResponse {
     private List<MistakeTagResponse> tags;
     private Integer commentCount;
     private Integer likeCount;
+    private Long memberId;
+    private String memberName;
+    private String memberImage;
 
     @Builder
-    public MistakeResponse(Long id, String content, List<MistakeTagResponse> tags, Integer commentCount, Integer likeCount) {
+    public MistakeResponse(Long id, String content, List<MistakeTagResponse> tags, Integer commentCount, Integer likeCount, Long memberId, String memberName, String memberImage) {
         this.id = id;
         this.content = content;
         this.tags = tags;
         this.commentCount = commentCount;
         this.likeCount = likeCount;
+        this.memberId = memberId;
+        this.memberName = memberName;
+        this.memberImage = memberImage;
     }
 
     public static MistakeResponse from(Mistake mistake) {
@@ -40,6 +46,9 @@ public class MistakeResponse {
                 .commentCount(mistake.getComments().size())
                 .likeCount(mistake.getLikes().size())
                 .tags(tag)
+                .memberId(mistake.getMember().getId())
+                .memberName(mistake.getMember().getNickname())
+                .memberImage(mistake.getMember().getImageName())
                 .build();
     }
 


### PR DESCRIPTION
## 🔥 관련 이슈
Issue: #117 

## ✨ 변경사항
- 실수 조회 시 회원의 정보 포함하여 반환

## 📝 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?

