### PR TITLE
fix: [#141] 생성자에서 Tag.mistakes 필드 초기화

### DIFF
--- a/src/main/java/weavers/siltarae/tag/domain/Tag.java
+++ b/src/main/java/weavers/siltarae/tag/domain/Tag.java
@@ -9,6 +9,7 @@ import weavers.siltarae.global.BaseEntity;
 import weavers.siltarae.mistake.domain.Mistake;
 import weavers.siltarae.member.domain.Member;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -33,11 +34,11 @@ public class Tag extends BaseEntity {
     private List<Mistake> mistakes;
 
     @Builder
-    public Tag(Long id, String name, Member member, List<Mistake> mistakes) {
+    public Tag(Long id, String name, Member member) {
         this.id = id;
         this.name = name;
         this.member = member;
-        this.mistakes = mistakes;
+        this.mistakes = new ArrayList<>();
     }
 
     @Override


### PR DESCRIPTION
## 🔥 관련 이슈
close #141 

## ✨ 변경사항
생성자에서 Tag.mistakes 필드에 새 리스트를 할당해주었어요.

## 📝 작업 유형
- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
