### PR TITLE
feat: [#147] 프로필 이미지 삭제 API 추가

### DIFF
--- a/src/main/java/weavers/siltarae/member/controller/MemberController.java
+++ b/src/main/java/weavers/siltarae/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import weavers.siltarae.login.Auth;
+import weavers.siltarae.member.dto.response.MemberImageResponse;
 import weavers.siltarae.member.dto.response.MemberInfoResponse;
 import weavers.siltarae.member.dto.response.MemberNicknameResponse;
 import weavers.siltarae.member.dto.request.MemberUpdateRequest;
@@ -32,6 +33,13 @@ public class MemberController {
         String imageUrl = memberService.uploadMemberImage(memberId, file);
 
         return ResponseEntity.created(URI.create(imageUrl)).build();
+    }
+
+    @DeleteMapping("/image")
+    public ResponseEntity<MemberImageResponse> deleteMemberImage(@Auth Long memberId) {
+        MemberImageResponse response = memberService.deleteMemberImage(memberId);
+
+        return ResponseEntity.ok(response);
     }
 
     @PutMapping

--- a/src/main/java/weavers/siltarae/member/dto/response/MemberImageResponse.java
+++ b/src/main/java/weavers/siltarae/member/dto/response/MemberImageResponse.java
@@ -1,0 +1,24 @@
+package weavers.siltarae.member.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberImageResponse {
+
+    private String imageUrl;
+
+    @Builder
+    public MemberImageResponse(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public static MemberImageResponse from (String imageUrl) {
+        return MemberImageResponse.builder()
+                .imageUrl(imageUrl)
+                .build();
+    }
+}

--- a/src/main/java/weavers/siltarae/member/service/MemberService.java
+++ b/src/main/java/weavers/siltarae/member/service/MemberService.java
@@ -11,6 +11,7 @@ import weavers.siltarae.global.image.domain.Image;
 import weavers.siltarae.login.domain.TokenProvider;
 import weavers.siltarae.member.domain.Member;
 import weavers.siltarae.member.domain.repository.MemberRepository;
+import weavers.siltarae.member.dto.response.MemberImageResponse;
 import weavers.siltarae.member.dto.response.MemberInfoResponse;
 import weavers.siltarae.member.dto.response.MemberNicknameResponse;
 import weavers.siltarae.member.dto.request.MemberUpdateRequest;
@@ -55,13 +56,16 @@ public class MemberService {
         return imageUrl;
     }
 
-    public void deleteMemberImage(Long memberId) {
+    public MemberImageResponse deleteMemberImage(Long memberId) {
         Member member = memberRepository.findByIdAndDeletedAtIsNull(memberId)
                 .orElseThrow(() -> new BadRequestException(NOT_FOUND_MEMBER));
 
-        if(member.hasDefaultImage()) return;
+        if(!member.hasDefaultImage()) {
+            imageUtil.deleteImage(folder, member.getImageName());
+            member.updateImage(member.getDefaultImage());
+        }
 
-        imageUtil.deleteImage(folder, member.getImageName());
+        return MemberImageResponse.from(member.getDefaultImage());
     }
 
     public MemberNicknameResponse changeMemberNickname(Long memberId, MemberUpdateRequest request) {


### PR DESCRIPTION
## 🔥 관련 이슈
close #147 

## ✨ 변경사항
프로필 이미지 삭제 API를 추가했어요. 이제 사용자는 기본 이미지로 되돌아갈 수 있어요.

## 📝 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?