### PR TITLE
refactor: [#148] 프로필 이미지 관련 기능 리팩토링

### DIFF
--- a/src/main/java/weavers/siltarae/global/image/ImageUtil.java
+++ b/src/main/java/weavers/siltarae/global/image/ImageUtil.java
@@ -23,7 +23,7 @@ public class ImageUtil {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    public String uploadImage(String folder, Image image) throws IOException {
+    public String uploadImage(String folder, Image image) {
         String path = folder + image.getName();
         ObjectMetadata metadata = new ObjectMetadata();
 
@@ -35,6 +35,8 @@ public class ImageUtil {
             s3Client.putObject(bucket, path, inputStream, metadata);
         } catch(AmazonServiceException e) {
             throw new BadRequestException(INVALID_IMAGE_PATH);
+        } catch(IOException e) {
+            throw new BadRequestException(FAIL_TO_UPLOAD_IMAGE);
         }
 
         return s3Client.getUrl(bucket, path).toString();

--- a/src/main/java/weavers/siltarae/global/image/domain/Image.java
+++ b/src/main/java/weavers/siltarae/global/image/domain/Image.java
@@ -20,13 +20,20 @@ public class Image {
     private final String name;
 
     public Image(MultipartFile file) {
-        validateEmptyImage(file);
+        validateEmptyFile(file);
+        validateImageFile(file);
         this.file = file;
         this.name = createUUIDName(file);
     }
 
-    public void validateEmptyImage(MultipartFile image) {
-        if(image.isEmpty() || !image.getContentType().startsWith("image")) {
+    private void validateEmptyFile(MultipartFile file) {
+        if(file == null || file.isEmpty()) {
+            throw new BadRequestException(INVALID_IMAGE_FILE);
+        }
+    }
+
+    private void validateImageFile(MultipartFile file) {
+        if(file.getContentType() == null || !file.getContentType().startsWith("image")) {
             throw new BadRequestException(INVALID_IMAGE_FILE);
         }
     }

--- a/src/main/java/weavers/siltarae/global/image/domain/Image.java
+++ b/src/main/java/weavers/siltarae/global/image/domain/Image.java
@@ -1,6 +1,7 @@
 package weavers.siltarae.global.image.domain;
 
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FilenameUtils;
 import org.springframework.web.multipart.MultipartFile;
 import weavers.siltarae.global.exception.BadRequestException;
@@ -9,6 +10,7 @@ import java.util.UUID;
 
 import static weavers.siltarae.global.exception.ExceptionCode.*;
 
+@Slf4j
 @Getter
 public class Image {
 
@@ -31,7 +33,7 @@ public class Image {
 
     private String createUUIDName(MultipartFile image) {
         String name = UUID.randomUUID().toString();
-        String fileExtension = EXTENSION_DELIMITER + FilenameUtils.getExtension(image.getName());
+        String fileExtension = EXTENSION_DELIMITER + FilenameUtils.getExtension(image.getOriginalFilename());
 
         return name + fileExtension;
     }

--- a/src/main/java/weavers/siltarae/member/controller/MemberController.java
+++ b/src/main/java/weavers/siltarae/member/controller/MemberController.java
@@ -11,8 +11,6 @@ import weavers.siltarae.member.dto.response.MemberNicknameResponse;
 import weavers.siltarae.member.dto.request.MemberUpdateRequest;
 import weavers.siltarae.member.service.MemberService;
 
-import java.net.URI;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/member")
@@ -27,17 +25,9 @@ public class MemberController {
         return ResponseEntity.ok(response);
     }
 
-    @PostMapping("/image")
-    public ResponseEntity<Void> uploadMemberImage(@Auth Long memberId, @RequestPart MultipartFile file) {
-        memberService.deleteMemberImage(memberId);
-        String imageUrl = memberService.uploadMemberImage(memberId, file);
-
-        return ResponseEntity.created(URI.create(imageUrl)).build();
-    }
-
-    @DeleteMapping("/image")
-    public ResponseEntity<MemberImageResponse> deleteMemberImage(@Auth Long memberId) {
-        MemberImageResponse response = memberService.deleteMemberImage(memberId);
+    @PutMapping("/image")
+    public ResponseEntity<MemberImageResponse> changeMemberImage(@Auth Long memberId, @RequestPart(required = false) MultipartFile file) {
+        MemberImageResponse response = memberService.updateMemberImage(memberId, file);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/weavers/siltarae/member/controller/MemberController.java
+++ b/src/main/java/weavers/siltarae/member/controller/MemberController.java
@@ -25,9 +25,16 @@ public class MemberController {
         return ResponseEntity.ok(response);
     }
 
-    @PutMapping("/image")
-    public ResponseEntity<MemberImageResponse> changeMemberImage(@Auth Long memberId, @RequestPart(required = false) MultipartFile file) {
+    @PostMapping("/image")
+    public ResponseEntity<MemberImageResponse> uploadMemberImage(@Auth Long memberId, @RequestPart MultipartFile file) {
         MemberImageResponse response = memberService.updateMemberImage(memberId, file);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/image")
+    public ResponseEntity<MemberImageResponse> deleteMemberImage(@Auth Long memberId) {
+        MemberImageResponse response = memberService.updateMemberImage(memberId);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/weavers/siltarae/member/domain/Member.java
+++ b/src/main/java/weavers/siltarae/member/domain/Member.java
@@ -58,7 +58,7 @@ public class Member extends BaseEntity {
         return this.getImageUrl().equals(DEFAULT_IMAGE);
     }
 
-    public String getDefaultImage() {
+    public String getDefaultImageUrl() {
         return DEFAULT_IMAGE;
     }
 

--- a/src/main/java/weavers/siltarae/member/service/MemberService.java
+++ b/src/main/java/weavers/siltarae/member/service/MemberService.java
@@ -33,15 +33,13 @@ public class MemberService {
     private String folder;
 
     public MemberInfoResponse getMemberInfo(Long memberId) {
-        Member member = memberRepository.findByIdAndDeletedAtIsNull(memberId)
-                .orElseThrow(() -> new BadRequestException(NOT_FOUND_MEMBER));
+        Member member = findMember(memberId);
 
         return MemberInfoResponse.from(member);
     }
 
     public String uploadMemberImage(Long memberId, MultipartFile file) {
-        Member member = memberRepository.findByIdAndDeletedAtIsNull(memberId)
-                .orElseThrow(() -> new BadRequestException(NOT_FOUND_MEMBER));
+        Member member = findMember(memberId);
 
         Image image = new Image(file);
         String imageUrl;
@@ -57,8 +55,7 @@ public class MemberService {
     }
 
     public MemberImageResponse deleteMemberImage(Long memberId) {
-        Member member = memberRepository.findByIdAndDeletedAtIsNull(memberId)
-                .orElseThrow(() -> new BadRequestException(NOT_FOUND_MEMBER));
+        Member member = findMember(memberId);
 
         if(!member.hasDefaultImage()) {
             imageUtil.deleteImage(folder, member.getImageName());
@@ -69,8 +66,7 @@ public class MemberService {
     }
 
     public MemberNicknameResponse changeMemberNickname(Long memberId, MemberUpdateRequest request) {
-        Member member = memberRepository.findByIdAndDeletedAtIsNull(memberId)
-                .orElseThrow(() -> new BadRequestException(NOT_FOUND_MEMBER));
+        Member member = findMember(memberId);
 
         member.updateNickname(request.getNickname());
 
@@ -78,8 +74,7 @@ public class MemberService {
     }
 
     public void deleteMember(Long memberId, String refreshToken) {
-        Member member = memberRepository.findByIdAndDeletedAtIsNull(memberId)
-                .orElseThrow(() -> new BadRequestException(NOT_FOUND_MEMBER));
+        Member member = findMember(memberId);
 
         if(!member.hasDefaultImage()) {
             imageUtil.deleteImage(folder, member.getImageName());
@@ -87,5 +82,10 @@ public class MemberService {
         member.delete();
 
         tokenProvider.deleteRefreshToken(refreshToken);
+    }
+
+    private Member findMember(Long memberId) {
+        return memberRepository.findByIdAndDeletedAtIsNull(memberId)
+                .orElseThrow(() -> new BadRequestException(NOT_FOUND_MEMBER));
     }
 }

--- a/src/main/java/weavers/siltarae/member/service/MemberService.java
+++ b/src/main/java/weavers/siltarae/member/service/MemberService.java
@@ -39,13 +39,17 @@ public class MemberService {
 
     public MemberImageResponse updateMemberImage(Long memberId, MultipartFile file) {
         Member member = findMember(memberId);
+        String imageUrl = uploadMemberImage(file);
 
-        String imageUrl;
-        if (file == null || file.isEmpty()) {
-            imageUrl = member.getDefaultImageUrl();
-        } else {
-            imageUrl = uploadMemberImage(file);
-        }
+        deleteMemberImage(member);
+        member.updateImage(imageUrl);
+
+        return MemberImageResponse.from(imageUrl);
+    }
+
+    public MemberImageResponse updateMemberImage(Long memberId) {
+        Member member = findMember(memberId);
+        String imageUrl = member.getDefaultImageUrl();
 
         deleteMemberImage(member);
         member.updateImage(imageUrl);


### PR DESCRIPTION
## 🔥 관련 이슈
close #148 

## ✨ 변경사항
- 프로필 이미지 업로드를 프로필 이미지 업데이트로 변경했어요. 이미지 파일이 없으면, 프로필 이미지를 기본 이미지로 변경해요. 이미지 업로드 중 에러가 발생하면, 예외 코드를 리턴해요.
- 업로드한 파일이 비어있는지 검증하는 로직과, 이미지 파일인지 검증하는 로직을 별도의 메서드로 분리했어요.
- 파일의 확장자가 제대로 추출되지 않는 버그를 수정했어요.

## 👀 리뷰 포인트
- `MemberService.updateMemberImage()`에서 이미 빈 파일인지 검사했어요. 그런데 `Image` 클래스에서 또 빈 파일인지 검사할 필요가 있을까요? 저는 클래스의 책임이나, 다른 이미지 업로드 기능을 생각하면 이미지 클래스에서도 검사하는 게 맞을 것 같은데 여기서는 불필요하게 두 번 검사하는게 아닌가 싶어서요. (이래서 null을 하나의 상태로 쓰고 싶지 않았어요..🥲)
- `null`을 하나의 상태로 간주해서 컨트롤러 매개변수로 file이 들어오면 프로필 이미지를 업데이트하고, 그렇지 않으면 기본 이미지로 설정하는 로직으로 구성했어요. 괜찮을까요?🤔 

## 📝 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
