### PR TITLE
refactor: [#139] Test 유저 가져오는 것 실제 Member 로 변경

### DIFF
--- a/src/main/java/weavers/siltarae/comment/domain/repository/CommentRepository.java
+++ b/src/main/java/weavers/siltarae/comment/domain/repository/CommentRepository.java
@@ -11,5 +11,5 @@ import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     Page<Comment> findByMistakeAndDeletedAtIsNullOrderByIdDesc(Mistake mistake, Pageable pageable);
-    Optional<Comment> findByIdAndMemberAndDeletedAtIsNull(Long id, Member member);
+    Optional<Comment> findByIdAndMember_IdAndDeletedAtIsNull(Long id, Long memberId);
 }

--- a/src/main/java/weavers/siltarae/comment/service/CommentService.java
+++ b/src/main/java/weavers/siltarae/comment/service/CommentService.java
@@ -36,7 +36,7 @@ public class CommentService {
     public CommentResponse save(CommentCreateRequest request, Long memberId) {
         Comment comment = commentRepository.save(
                 Comment.builder()
-                        .member(getTestUser(memberId))
+                        .member(getMemberFromId(memberId))
                         .mistake(getMistake(request.getMistakeId()))
                         .content(request.getContent())
                         .build()
@@ -51,20 +51,20 @@ public class CommentService {
     }
 
     public void delete(Long commentId, Long memberId) {
-        Comment comment = findMyComment(commentId, getTestUser(memberId));
+        Comment comment = findMyComment(commentId, memberId);
 
         comment.delete();
     }
 
-    private Comment findMyComment(Long commentId, Member member) {
-        return commentRepository.findByIdAndMemberAndDeletedAtIsNull(commentId, member).orElseThrow(() -> new BadRequestException(ExceptionCode.COMMENT_VALID_ERROR));
+    private Comment findMyComment(Long commentId, Long memberId) {
+        return commentRepository.findByIdAndMember_IdAndDeletedAtIsNull(commentId, memberId).orElseThrow(() -> new BadRequestException(ExceptionCode.COMMENT_VALID_ERROR));
     }
 
     private Mistake getMistake(Long mistakeId) {
         return mistakeRepository.findByIdAndDeletedAtIsNull(mistakeId).orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_MISTAKE));
     }
 
-    private Member getTestUser(Long memberId) {
+    private Member getMemberFromId(Long memberId) {
         return memberRepository.findById(memberId).orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_MEMBER));
     }
 }

--- a/src/main/java/weavers/siltarae/like/service/LikeService.java
+++ b/src/main/java/weavers/siltarae/like/service/LikeService.java
@@ -12,8 +12,6 @@ import weavers.siltarae.member.domain.repository.MemberRepository;
 import weavers.siltarae.mistake.domain.Mistake;
 import weavers.siltarae.mistake.domain.repository.MistakeRepository;
 
-import java.util.Objects;
-
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -25,7 +23,7 @@ public class LikeService {
 
 
     public void like(Long memberId, Long mistakeId) {
-        Member member = getTestUser(memberId);
+        Member member = getMemberFromId(memberId);
         Mistake mistake = getMistake(mistakeId);
 
         toggleLike(member, mistake);
@@ -55,7 +53,7 @@ public class LikeService {
         return mistakeRepository.findById(mistakeId).orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_MISTAKE));
     }
 
-    private Member getTestUser(Long memberId) {
+    private Member getMemberFromId(Long memberId) {
         return memberRepository.findById(memberId).orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_MEMBER));
     }
 }

--- a/src/main/java/weavers/siltarae/mistake/domain/repository/MistakeRepository.java
+++ b/src/main/java/weavers/siltarae/mistake/domain/repository/MistakeRepository.java
@@ -3,7 +3,6 @@ package weavers.siltarae.mistake.domain.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import weavers.siltarae.member.domain.Member;
 import weavers.siltarae.mistake.domain.Mistake;
 
 import java.util.List;
@@ -11,8 +10,7 @@ import java.util.Optional;
 
 public interface MistakeRepository extends JpaRepository<Mistake, Long>, MistakeQRepository {
     Page<Mistake> findByMember_IdAndDeletedAtIsNullOrderByIdDesc(Long memberId, Pageable pageable);
-    Optional<Mistake> findByIdAndMemberAndDeletedAtIsNull(Long id, Member member);
-    List<Mistake> findByIdInAndMemberAndDeletedAtIsNull(List<Long> id, Member member);
+    List<Mistake> findByIdInAndMember_IdAndDeletedAtIsNull(List<Long> id, Long memberId);
     Optional<Mistake> findByIdAndDeletedAtIsNull(Long id);
     Page<Mistake> findByDeletedAtIsNullOrderByIdDesc(Pageable pageable);
     Page<Mistake> findByMember_IdAndTags_IdInAndDeletedAtIsNullOrderByIdDesc(Long memberId, List<Long> tagIds, Pageable pageable);

--- a/src/main/java/weavers/siltarae/mistake/service/MistakeService.java
+++ b/src/main/java/weavers/siltarae/mistake/service/MistakeService.java
@@ -34,7 +34,7 @@ public class MistakeService {
             MistakeCreateRequest request, Long memberId) {
         Mistake mistake = mistakeRepository.save(
                 Mistake.builder()
-                        .member(getTestUser(memberId))
+                        .member(getMemberFromId(memberId))
                         .content(request.getContent())
                         .tags(getTags(request.getTagIds(), memberId))
                         .build()
@@ -86,12 +86,12 @@ public class MistakeService {
     @Transactional
     public void deleteMistake(Long memberId, List<Long> mistakeIds) {
         List<Mistake> mistakes
-                = mistakeRepository.findByIdInAndMemberAndDeletedAtIsNull(mistakeIds, getTestUser(memberId));
+                = mistakeRepository.findByIdInAndMember_IdAndDeletedAtIsNull(mistakeIds, memberId);
 
         mistakes.forEach(Mistake::delete);
     }
 
-    private Member getTestUser(Long memberId) {
+    private Member getMemberFromId(Long memberId) {
         return memberRepository.findById(memberId).orElseThrow(() -> new BadRequestException(ExceptionCode.INVALID_MISTAKE_CONTENT_NULL));
     }
 


### PR DESCRIPTION
## 🔥 관련 이슈
Issue: Close #139 

## ✨ 변경사항
- getTestUser 의 메소드를 getMemberFromId 로 메소드명을 변경해주었습니다.
- Member 객체를 이용하여 조회하는 부분을 MemberId 를 이용하여 조회하는 것으로 변경해주었습니다. 이유는 이미 토큰을 활용해서 회원을 검증하는 데 DB 조회를 이용하여 다시 한번 회원을 검증하는 것을 이중으로 할 필요가 없다고 판단하였습니다.

## 📝 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?

