### PR TITLE
fix: [#138] 실수와 피드 목록에서 삭제된 댓글도 카운팅 되서 반환되는 것 수정

### DIFF
--- a/src/main/java/weavers/siltarae/mistake/controller/FeedController.java
+++ b/src/main/java/weavers/siltarae/mistake/controller/FeedController.java
@@ -21,7 +21,7 @@ public class FeedController {
 
     @GetMapping
     @Operation(summary = "피드 조회")
-    public ResponseEntity<FeedListResponse> getfeeds(
+    public ResponseEntity<FeedListResponse> getFeeds(
             @Valid FeedRequest request) {
 
         return ResponseEntity.ok(feedService.getfeedList(request));

--- a/src/main/java/weavers/siltarae/mistake/domain/Mistake.java
+++ b/src/main/java/weavers/siltarae/mistake/domain/Mistake.java
@@ -50,7 +50,7 @@ public class Mistake extends BaseEntity {
         this.likes = likes;
     }
 
-    public Integer getNotDeleteCommentCount(Mistake mistake) {
+    public Integer getExistingCommentCount(Mistake mistake) {
         return mistake.getComments().stream()
                 .filter(comment -> comment.getDeletedAt() == null)
                 .mapToInt(comment -> 1)

--- a/src/main/java/weavers/siltarae/mistake/domain/Mistake.java
+++ b/src/main/java/weavers/siltarae/mistake/domain/Mistake.java
@@ -50,4 +50,11 @@ public class Mistake extends BaseEntity {
         this.likes = likes;
     }
 
+    public Integer getNotDeleteCommentCount(Mistake mistake) {
+        return mistake.getComments().stream()
+                .filter(comment -> comment.getDeletedAt() == null)
+                .mapToInt(comment -> 1)
+                .sum();
+    }
+
 }

--- a/src/main/java/weavers/siltarae/mistake/dto/response/FeedListResponse.java
+++ b/src/main/java/weavers/siltarae/mistake/dto/response/FeedListResponse.java
@@ -7,7 +7,6 @@ import org.springframework.data.domain.Page;
 import weavers.siltarae.mistake.domain.Mistake;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static lombok.AccessLevel.PROTECTED;
 

--- a/src/main/java/weavers/siltarae/mistake/dto/response/FeedResponse.java
+++ b/src/main/java/weavers/siltarae/mistake/dto/response/FeedResponse.java
@@ -31,7 +31,7 @@ public class FeedResponse {
         return FeedResponse.builder()
                 .id(mistake.getId())
                 .content(mistake.getContent())
-                .commentCount(mistake.getNotDeleteCommentCount(mistake))
+                .commentCount(mistake.getExistingCommentCount(mistake))
                 .likeCount(mistake.getLikes().size())
                 .memberId(mistake.getMember().getId())
                 .memberName(mistake.getMember().getNickname())

--- a/src/main/java/weavers/siltarae/mistake/dto/response/FeedResponse.java
+++ b/src/main/java/weavers/siltarae/mistake/dto/response/FeedResponse.java
@@ -31,7 +31,7 @@ public class FeedResponse {
         return FeedResponse.builder()
                 .id(mistake.getId())
                 .content(mistake.getContent())
-                .commentCount(mistake.getComments().size())
+                .commentCount(mistake.getNotDeleteCommentCount(mistake))
                 .likeCount(mistake.getLikes().size())
                 .memberId(mistake.getMember().getId())
                 .memberName(mistake.getMember().getNickname())

--- a/src/main/java/weavers/siltarae/mistake/dto/response/MistakeResponse.java
+++ b/src/main/java/weavers/siltarae/mistake/dto/response/MistakeResponse.java
@@ -43,7 +43,7 @@ public class MistakeResponse {
         return MistakeResponse.builder()
                 .id(mistake.getId())
                 .content(mistake.getContent())
-                .commentCount(mistake.getComments().size())
+                .commentCount(mistake.getNotDeleteCommentCount(mistake))
                 .likeCount(mistake.getLikes().size())
                 .tags(tag)
                 .memberId(mistake.getMember().getId())

--- a/src/main/java/weavers/siltarae/mistake/dto/response/MistakeResponse.java
+++ b/src/main/java/weavers/siltarae/mistake/dto/response/MistakeResponse.java
@@ -43,7 +43,7 @@ public class MistakeResponse {
         return MistakeResponse.builder()
                 .id(mistake.getId())
                 .content(mistake.getContent())
-                .commentCount(mistake.getNotDeleteCommentCount(mistake))
+                .commentCount(mistake.getExistingCommentCount(mistake))
                 .likeCount(mistake.getLikes().size())
                 .tags(tag)
                 .memberId(mistake.getMember().getId())


### PR DESCRIPTION
## 🔥 관련 이슈
Issue: #138 

## ✨ 변경사항
- 기존에는 실수와 피드 목록에서 삭제된 댓글도 카운팅 되서 반환되었지만 이 부분을 삭제된 댓글은 카운팅 되지 않게끔 수정하였습니다

## 📝 작업 유형
- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?

