### PR TITLE
refactor: [#158] https://localhost 요청 허용

### DIFF
--- a/src/main/java/weavers/siltarae/global/config/CorsConfig.java
+++ b/src/main/java/weavers/siltarae/global/config/CorsConfig.java
@@ -12,7 +12,7 @@ public class CorsConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:3000", "https://siltarae.me")
+                .allowedOrigins("http://localhost:3000", "https://siltarae.me", "https://localhost:3000")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
                 .exposedHeaders(AUTHORIZATION)
                 .allowCredentials(true);


### PR DESCRIPTION
## 🔥 관련 이슈
Issue: #158 

## ✨ 변경사항
- https://localhost 으로 들어오는 요청도 허용하였습니다
- 구글 로그인 진행 중에 https 가 아니면 리프레쉬 토큰을 받아올 수 없어서 테스트 환경에서도 https 를 적용하였기에 서버에서도 https 를 허용하기로 하였습니다

## 📝 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?

