### PR TITLE
refactor: HTTP 요청 생성 메서드를 테스트 메서드 안으로 병합

### DIFF
--- a/src/test/java/weavers/siltarae/integration/member/MemberIntegrationTest.java
+++ b/src/test/java/weavers/siltarae/integration/member/MemberIntegrationTest.java
@@ -1,14 +1,10 @@
 package weavers.siltarae.integration.member;
 
-import io.restassured.RestAssured;
-import io.restassured.response.ExtractableResponse;
-import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
 import weavers.siltarae.integration.BaseIntegrationTest;
-import weavers.siltarae.login.dto.response.TokenPair;
 
+import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.*;
-import static org.assertj.core.api.Assertions.*;
 import static org.springframework.http.HttpHeaders.*;
 import static org.springframework.http.HttpStatus.*;
 
@@ -17,48 +13,28 @@ class MemberIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void 최대크기를_초과하는_이미지를_업로드하면_예외가_발생한다() {
-        // given
         byte[] bytes = new byte[1024 * 1024 * 6];
 
-        // when
-        ExtractableResponse<Response> response = requestUpdateMemberImage(tokenPair, bytes);
-
-        // then
-        assertThat(response.statusCode()).isEqualTo(PAYLOAD_TOO_LARGE.value());
+        given().log().all()
+                .header(AUTHORIZATION, tokenPair.getAccessToken())
+                .cookie("refresh-token", tokenPair.getRefreshToken())
+                .contentType(MULTIPART)
+                .multiPart("file", "big_image.png", bytes, "image/png")
+        .when().post("/api/v1/member/image")
+        .then().log().all()
+                .statusCode(PAYLOAD_TOO_LARGE.value());
     }
 
     @Test
     void 이미지가_비어있는_경우_예외가_발생한다() {
-        // given
 
-        // when
-        ExtractableResponse<Response> response = requestUpdateEmptyMemberImage(tokenPair);
-
-        // then
-        assertThat(response.statusCode()).isEqualTo(BAD_REQUEST.value());
-    }
-
-    private static ExtractableResponse<Response> requestUpdateMemberImage(TokenPair tokenPair, byte[] bytes) {
-        return RestAssured
-                .given().log().all()
-                .header(AUTHORIZATION, "Bearer " + tokenPair.getAccessToken())
-                .cookie("refresh-token", tokenPair.getRefreshToken())
-                .contentType(MULTIPART)
-                .multiPart("file", "big_image.png", bytes, "image/png")
-                .when().post("/api/v1/member/image")
-                .then().log().all()
-                .extract();
-    }
-
-    private static ExtractableResponse<Response> requestUpdateEmptyMemberImage(TokenPair tokenPair) {
-        return RestAssured
-                .given().log().all()
-                .header(AUTHORIZATION, "Bearer " + tokenPair.getAccessToken())
+        given().log().all()
+                .header(AUTHORIZATION, tokenPair.getAccessToken())
                 .cookie("refresh-token", tokenPair.getRefreshToken())
                 .contentType(MULTIPART)
                 .multiPart("file", "empty_image.png", "image/png")
-                .when().post("/api/v1/member/image")
-                .then().log().all()
-                .extract();
+        .when().post("/api/v1/member/image")
+        .then().log().all()
+                .statusCode(BAD_REQUEST.value());
     }
 }


### PR DESCRIPTION
## 🔥 관련 이슈
Issue: #148 

## ✨ 변경사항
- HTTP 요청을 생성하는 부분을 테스트 메서드 안으로 병합했어요.
- given-when-then 구조가 더 잘 보여요!

## 📝 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?

## 추가 설명
없으면 생략 가능합니다.
