### PR TITLE
refactor: getMistakeList() 메서드 개선

### DIFF
--- a/src/main/java/weavers/siltarae/global/exception/ExceptionCode.java
+++ b/src/main/java/weavers/siltarae/global/exception/ExceptionCode.java
@@ -7,14 +7,15 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ExceptionCode {
     INVALID_REQUEST(1000, "올바르지 않은 요청입니다."),
-    DUPLICATED_TAG_NAME(3001, "중복된 태그명입니다."),
 
     INVALID_MISTAKE_CONTENT_SIZE(2001, "실수 내용은 140자가 넘을 수 없습니다."),
     INVALID_MISTAKE_CONTENT_NULL(2002, "실수 내용은 필수입니다."),
     INVALID_MISTAKE_CONTENT(2003, "실수 내용에는 한글, 영어, 숫자만 허용됩니다."),
     NOT_FOUND_MISTAKE(2004, "해당하는 실수가 존재하지 않습니다."),
 
+    DUPLICATED_TAG_NAME(3001, "중복된 태그명입니다."),
     NOT_FOUND_TAG(3002, "해당하는 태그가 존재하지 않습니다."),
+    NOT_FOUND_TAG_WITH_MEMBER(3003, "해당 회원의 태그가 아닙니다."),
 
     NOT_FOUND_MEMBER(4001, "해당하는 회원이 존재하지 않습니다."),
     INVALID_EMAIL(4002, "유효하지 않은 이메일입니다."),

--- a/src/main/java/weavers/siltarae/mistake/controller/FeedController.java
+++ b/src/main/java/weavers/siltarae/mistake/controller/FeedController.java
@@ -24,7 +24,7 @@ public class FeedController {
     public ResponseEntity<FeedListResponse> getFeeds(
             @Valid FeedRequest request) {
 
-        return ResponseEntity.ok(feedService.getfeedList(request));
+        return ResponseEntity.ok(feedService.getFeedList(request));
     }
 
 }

--- a/src/main/java/weavers/siltarae/mistake/service/FeedService.java
+++ b/src/main/java/weavers/siltarae/mistake/service/FeedService.java
@@ -17,7 +17,7 @@ import weavers.siltarae.mistake.dto.response.FeedListResponse;
 public class FeedService {
     private final MistakeRepository mistakeRepository;
 
-    public FeedListResponse getfeedList(FeedRequest request) {
+    public FeedListResponse getFeedList(FeedRequest request) {
         Page<Mistake> mistakes = switch (request.getFeedType()) {
             case FASTEST -> mistakeRepository.findByDeletedAtIsNullOrderByIdDesc(request.toPageable());
             case POPULAR -> mistakeRepository.findMistakesSortedByLikes(request.toPageable());

--- a/src/main/java/weavers/siltarae/tag/domain/repository/TagRepository.java
+++ b/src/main/java/weavers/siltarae/tag/domain/repository/TagRepository.java
@@ -9,5 +9,7 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
     boolean existsByMember_IdAndName(Long memberId, String name);
 
     List<Tag> findAllByMember_IdAndDeletedAtIsNull(Long userId);
+
+    List<Tag> findByIdInAndDeletedAtIsNull(List<Long> tagIds);
 }
 


### PR DESCRIPTION
## 🔥 관련 이슈
close #105 

## ✨ 변경사항
- `getMistakeList()`에서 던지는 예외 코드를 세분화했어요. 이제 태그 리스트로 실수를 조회할 때 삭제된 태그로 조회했는지, 아니면 다른 멤버의 태그로 조회했는지 구분할 수 있어요.
- `getLongs()`, `validateTag()` 메서드를 해체함으로써 호출 depth를 줄였어요. `validateTag()`는 검증 메서드를 호출하는 것 외에 별다른 책임이 없어서 해체하기로 결정했어요 👐 
- 사소한 내용이지만 메서드명 `getfeedList()`를 `getFeedList()`로 카멜 케이스에 맞게 변경했어요 👀 

## 📝 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
