### PR TITLE
feat: [#163] @Auth 어노테이션 필수여부 속성 및 관련 로직 추가

### DIFF
--- a/src/main/java/weavers/siltarae/login/AccessTokenExtractor.java
+++ b/src/main/java/weavers/siltarae/login/AccessTokenExtractor.java
@@ -1,11 +1,9 @@
 package weavers.siltarae.login;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import weavers.siltarae.global.exception.AuthException;
 import weavers.siltarae.global.exception.ExceptionCode;
 
-@Slf4j
 @Component
 public class AccessTokenExtractor {
 
@@ -13,7 +11,6 @@ public class AccessTokenExtractor {
 
     public String extractAccessToken(String authorizationHeader) {
         if(authorizationHeader==null || !authorizationHeader.startsWith(BEARER_TYPE)) {
-            log.info("=========== authorization header = {} ==========", authorizationHeader);
             throw new AuthException(ExceptionCode.AVAILABLE_AFTER_LOGIN);
         }
         return authorizationHeader.substring(BEARER_TYPE.length()).trim();

--- a/src/main/java/weavers/siltarae/login/Auth.java
+++ b/src/main/java/weavers/siltarae/login/Auth.java
@@ -8,4 +8,6 @@ import java.lang.annotation.Target;
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Auth {
+
+    boolean required() default true;
 }

--- a/src/main/java/weavers/siltarae/login/AuthArgumentResolver.java
+++ b/src/main/java/weavers/siltarae/login/AuthArgumentResolver.java
@@ -29,9 +29,16 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
 
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
-        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
-        String accessToken = accessTokenExtractor.extractAccessToken(request.getHeader(AUTHORIZATION));
+        Auth annotation = parameter.getParameterAnnotation(Auth.class);
 
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        String authorizationHeader = request.getHeader(AUTHORIZATION);
+
+        if(!annotation.required() && authorizationHeader==null) {
+            return null;
+        }
+
+        String accessToken = accessTokenExtractor.extractAccessToken(authorizationHeader);
         return tokenProvider.getMemberIdFromAccessToken(accessToken);
     }
 }


### PR DESCRIPTION
## 🔥 관련 이슈
close #163 

## ✨ 변경사항
- `@Auth` 어노테이션에 필수여부를 의미하는 `required` 속성을 추가했어요. 기본값은 true에요.
- 만약 `@Auth(required = false)`이고 HTTP Request에 Authorization 헤더가 존재하지 않으면, 컨트롤러 파라미터로 null을 넘겨요.
- 사소한 내용이지만 `AccessTokenExtractor` 클래스에 있던 로그를 삭제했어요 👀 

## 📝 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
