### PR TITLE
refactor: [#169] 댓글목록 및 피드목록 Response 에 회원의 이미지 정보 추가

### DIFF
--- a/src/main/java/weavers/siltarae/comment/dto/response/CommentResponse.java
+++ b/src/main/java/weavers/siltarae/comment/dto/response/CommentResponse.java
@@ -12,15 +12,17 @@ import static lombok.AccessLevel.PROTECTED;
 public class CommentResponse {
     private Long memberId;
     private String memberName;
+    private String memberImageUrl;
     private Long commentId;
     private String commentContent;
 
     @Builder
-    public CommentResponse(Long memberId, String memberName, Long commentId, String commentContent) {
+    public CommentResponse(Long memberId, String memberName, Long commentId, String commentContent, String memberImageUrl) {
         this.memberId = memberId;
         this.memberName = memberName;
         this.commentId = commentId;
         this.commentContent = commentContent;
+        this.memberImageUrl = memberImageUrl;
     }
 
     public static CommentResponse from(Comment comment) {
@@ -29,6 +31,7 @@ public class CommentResponse {
                 .commentContent(comment.getContent())
                 .memberId(comment.getMember().getId())
                 .memberName(comment.getMember().getNickname())
+                .memberImageUrl(comment.getMember().getImageUrl())
                 .build();
     }
 }

--- a/src/main/java/weavers/siltarae/mistake/dto/response/FeedResponse.java
+++ b/src/main/java/weavers/siltarae/mistake/dto/response/FeedResponse.java
@@ -16,10 +16,11 @@ public class FeedResponse {
     private Integer likeCount;
     private Long memberId;
     private String memberName;
+    private String memberImageUrl;
     private Boolean likeAble;
 
     @Builder
-    public FeedResponse(Long id, String content, Integer commentCount, Integer likeCount, Long memberId, String memberName, Boolean likeAble) {
+    public FeedResponse(Long id, String content, Integer commentCount, Integer likeCount, Long memberId, String memberName, Boolean likeAble, String memberImageUrl) {
         this.id = id;
         this.content = content;
         this.commentCount = commentCount;
@@ -27,6 +28,7 @@ public class FeedResponse {
         this.memberId = memberId;
         this.memberName = memberName;
         this.likeAble = likeAble;
+        this.memberImageUrl = memberImageUrl;
     }
 
     public static FeedResponse from(Mistake mistake, Boolean likeAble) {
@@ -37,6 +39,7 @@ public class FeedResponse {
                 .likeCount(mistake.getLikes().size())
                 .memberId(mistake.getMember().getId())
                 .memberName(mistake.getMember().getNickname())
+                .memberImageUrl(mistake.getMember().getImageUrl())
                 .likeAble(likeAble)
                 .build();
     }


### PR DESCRIPTION
## 🔥 관련 이슈
Issue: #169 

## ✨ 변경사항
- 댓글 목록 조회 시 회원의 이미지 정보를 추가하였습니다.
- 피드 목록 조회 시 회원의 이미지 정보를 추가하였습니다.

## 📝 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
