### PR TITLE
refactor: [#178] 다대다 연관관계 테이블 복합키 순서 변경

### DIFF
--- a/src/main/java/weavers/siltarae/mistake/domain/Mistake.java
+++ b/src/main/java/weavers/siltarae/mistake/domain/Mistake.java
@@ -30,7 +30,7 @@ public class Mistake extends BaseEntity {
     private String content;
 
     @ManyToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    @JoinTable(name = "tag_mistake",
+    @JoinTable(name = "mistake_tag",
             joinColumns = @JoinColumn(name = "mistake_id"),
             inverseJoinColumns = @JoinColumn(name = "tag_id"))
     private List<Tag> tags;

--- a/src/main/java/weavers/siltarae/tag/domain/Tag.java
+++ b/src/main/java/weavers/siltarae/tag/domain/Tag.java
@@ -28,7 +28,7 @@ public class Tag extends BaseEntity {
     private Member member;
 
     @ManyToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    @JoinTable(name = "tag_mistake",
+    @JoinTable(name = "mistake_tag",
         joinColumns = @JoinColumn(name = "tag_id"),
         inverseJoinColumns = @JoinColumn(name = "mistake_id"))
     private List<Mistake> mistakes;


### PR DESCRIPTION
## 🔥 관련 이슈
close #178 

## ✨ 변경사항
- `tag_mistake` 테이블명을 `mistake_tag`로 변경했어요.
- `(tag_id, mistake_id)` 순서로 걸려있던 인덱스를 `(mistake_id, tag_id)` 순서로 변경했어요.
<img width="536" alt="스크린샷 2024-01-24 오후 2 55 45" src="https://github.com/coding-union-kr/siltarae-be/assets/67768976/dde451f2-46b8-496d-92a1-dea9f8214f26">


## 📝 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
