### PR TITLE
refactor: [#168] 태그에 속한 실수 개수 카운트 시, 삭제된 실수 필터링 추가

### DIFF
--- a/src/main/java/weavers/siltarae/global/image/domain/Image.java
+++ b/src/main/java/weavers/siltarae/global/image/domain/Image.java
@@ -1,7 +1,6 @@
 package weavers.siltarae.global.image.domain;
 
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FilenameUtils;
 import org.springframework.web.multipart.MultipartFile;
 import weavers.siltarae.global.exception.BadRequestException;

--- a/src/main/java/weavers/siltarae/mistake/domain/repository/MistakeRepository.java
+++ b/src/main/java/weavers/siltarae/mistake/domain/repository/MistakeRepository.java
@@ -14,4 +14,5 @@ public interface MistakeRepository extends JpaRepository<Mistake, Long>, Mistake
     Optional<Mistake> findByIdAndDeletedAtIsNull(Long id);
     Page<Mistake> findByDeletedAtIsNullOrderByIdDesc(Pageable pageable);
     Page<Mistake> findByMember_IdAndTags_IdInAndDeletedAtIsNullOrderByIdDesc(Long memberId, List<Long> tagIds, Pageable pageable);
+    Long countByTags_IdAndDeletedAtIsNull(Long tagId);
 }

--- a/src/main/java/weavers/siltarae/tag/dto/response/TagListResponse.java
+++ b/src/main/java/weavers/siltarae/tag/dto/response/TagListResponse.java
@@ -4,10 +4,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import weavers.siltarae.tag.domain.Tag;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -23,10 +21,7 @@ public class TagListResponse {
         this.tags = tags;
     }
 
-    public static TagListResponse from(List<Tag> tagList) {
-        List<TagResponse> tagResponseList = tagList.stream()
-                .map(TagResponse::from).collect(Collectors.toList());
-
+    public static TagListResponse from(List<TagResponse> tagResponseList) {
         return TagListResponse.builder()
                 .totalCount(tagResponseList.size())
                 .tags(tagResponseList)

--- a/src/main/java/weavers/siltarae/tag/dto/response/TagResponse.java
+++ b/src/main/java/weavers/siltarae/tag/dto/response/TagResponse.java
@@ -13,20 +13,20 @@ public class TagResponse {
     private Long id;
     private String name;
 
-    private Integer mistakeCount;
+    private Long mistakeCount;
 
     @Builder
-    public TagResponse(Long id, String name, Integer mistakeCount) {
+    public TagResponse(Long id, String name, Long mistakeCount) {
         this.id = id;
         this.name = name;
         this.mistakeCount = mistakeCount;
     }
 
-    public static TagResponse from(Tag tag) {
+    public static TagResponse from(Tag tag, Long mistakeCount) {
         return TagResponse.builder()
                 .id(tag.getId())
                 .name(tag.getName())
-                .mistakeCount(tag.getMistakes().size())
+                .mistakeCount(mistakeCount)
                 .build();
     }
 }


### PR DESCRIPTION
## 🔥 관련 이슈
close #168 

## ✨ 변경사항
- 기존에는 `tag.mistakes.size()`를 통해 태그에 속한 실수 개수를 카운트하고 있었어요. 저희는 soft delete 전략을 채택하고 있었기 때문에, 삭제된 실수의 개수까지 포함되어 카운팅되는 문제가 발생했어요.
- 그래서 ResponseDTO 생성 시 태그에 속한 실수 개수는 별도의 쿼리로 조회한 값을 넣어주기로 했어요. `MistakeRepository.countByTags_IdAndDeletedAtIsNull(Long tagId)` 메서드를 추가하고, 이를 이용해 삭제된 실수는 카운팅에서 제외했어요.
- 사소한 부분이지만, `Image` 클래스에서 사용되지 않던 패키지(Slf4j)를 unimport 했어요.

## 👀 리뷰 포인트
기존에는 `TagListReponse`에서 `Tag` 엔티티에 의존했는데, 지금은 `TagListResponse` -> `TagResponse` -> `Tag` 순으로 의존하고 있어요. ResponseDTO가 다른 ResponseDTO에 의존하는 게 괜찮을까? 싶은 생각이 들어요🤔

## 📝 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
