### PR TITLE
refactor: [#188] 액세스 토큰 재발급 로직 수정

### DIFF
--- a/src/main/java/weavers/siltarae/login/domain/TokenProvider.java
+++ b/src/main/java/weavers/siltarae/login/domain/TokenProvider.java
@@ -16,6 +16,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.UUID;
 
+import static weavers.siltarae.global.exception.ExceptionCode.*;
+
 @Component
 public class TokenProvider {
 
@@ -91,15 +93,22 @@ public class TokenProvider {
 
     private void validateRefreshToken(final String token, final Long memberId) {
         RefreshToken refreshToken = refreshTokenRepository.findById(token)
-                .orElseThrow(() -> new RefreshTokenException(ExceptionCode.EXPIRED_REFRESH_TOKEN));
+                .orElseThrow(() -> new RefreshTokenException(EXPIRED_REFRESH_TOKEN));
 
         if(!memberId.equals(refreshToken.getMemberId())) {
-            throw new BadRequestException(ExceptionCode.INVALID_REFRESH_TOKEN);
+            throw new BadRequestException(INVALID_REFRESH_TOKEN);
         }
     }
 
     public Long getMemberIdFromAccessToken(final String accessToken) {
         return Long.parseLong(parseJwt(accessToken).getSubject());
+    }
+
+    public Long getMemberIdFromRefreshToken(final String refreshToken) {
+        RefreshToken token = refreshTokenRepository.findById(refreshToken)
+                .orElseThrow(() -> new RefreshTokenException(INVALID_REFRESH_TOKEN));
+
+        return token.getMemberId();
     }
 
     private Claims parseJwt(final String token) {
@@ -111,9 +120,9 @@ public class TokenProvider {
                     .getPayload();
 
         } catch (ExpiredJwtException e) {
-            throw new AccessTokenException(ExceptionCode.EXPIRED_ACCESS_TOKEN);
+            throw new AccessTokenException(EXPIRED_ACCESS_TOKEN);
         } catch (JwtException | IllegalArgumentException e) {
-            throw new BadRequestException(ExceptionCode.INVALID_ACCESS_TOKEN);
+            throw new BadRequestException(INVALID_ACCESS_TOKEN);
         }
     }
 

--- a/src/main/java/weavers/siltarae/login/service/LoginService.java
+++ b/src/main/java/weavers/siltarae/login/service/LoginService.java
@@ -42,7 +42,7 @@ public class LoginService {
             throw new AuthException(ExceptionCode.FAIL_TO_VALIDATE_TOKEN);
         }
 
-        Long memberId = tokenProvider.getMemberIdFromAccessToken(accessToken);
+        Long memberId = tokenProvider.getMemberIdFromRefreshToken(refreshToken);
         String newAccessToken = tokenProvider.renewAccessToken(memberId);
 
         return AccessTokenResponse.builder()

--- a/src/main/java/weavers/siltarae/login/service/LoginService.java
+++ b/src/main/java/weavers/siltarae/login/service/LoginService.java
@@ -24,7 +24,7 @@ public class LoginService {
     private final TokenProvider tokenProvider;
     private final GoogleProvider googleProvider;
 
-    public TokenPair login(String socialType, String code) {
+    public TokenPair login(String code) {
         String authAccessToken = googleProvider.requestAccessToken(code);
         MemberInfoResponse memberInfo = googleProvider.getMemberInfo(authAccessToken);
 


### PR DESCRIPTION
## 🔥 관련 이슈
close #188 

## ✨ 변경사항
- 기존에는 액세스 토큰 재발급 시, 회원 정보를 액세스 토큰에서 불러오고 있었어요.
- 하지만 액세스 토큰을 재발급한다는 건 액세스 토큰이 만료되었다는 의미이기 때문에, Exception이 발생할 가능성이 있어요.
- 그래서 회원 정보를 리프레시 토큰을 통해 조회하도록 로직을 변경했어요.
- `LoginService.login()` 메서드에서 불필요한 파라미터 `socialType`을 제거했어요. 원래는 카카오 로그인이 추가될 때를 대비해서 만들어두었는데, 카카오 로그인을 구현하지 않게 되어 삭제했어요.

## 📝 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
