### PR TITLE
refactor: [#194] 로그인 성공 시, 토큰 정보와 회원 정보를 함께 반환하도록 수정

### DIFF
--- a/src/main/java/weavers/siltarae/login/AuthArgumentResolver.java
+++ b/src/main/java/weavers/siltarae/login/AuthArgumentResolver.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
-import weavers.siltarae.login.domain.TokenProvider;
+import weavers.siltarae.login.infrastructure.TokenProvider;
 
 import static org.springframework.http.HttpHeaders.*;
 

--- a/src/main/java/weavers/siltarae/login/domain/LoginInfo.java
+++ b/src/main/java/weavers/siltarae/login/domain/LoginInfo.java
@@ -4,7 +4,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import weavers.siltarae.login.dto.response.TokenPair;
 import weavers.siltarae.member.domain.Member;
 
 @Getter

--- a/src/main/java/weavers/siltarae/login/domain/LoginInfo.java
+++ b/src/main/java/weavers/siltarae/login/domain/LoginInfo.java
@@ -1,0 +1,42 @@
+package weavers.siltarae.login.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import weavers.siltarae.login.dto.response.TokenPair;
+import weavers.siltarae.member.domain.Member;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class LoginInfo {
+
+    private Long memberId;
+    private String nickname;
+    private String profileImage;
+    private String accessToken;
+    private String refreshToken;
+
+    private Long refreshTokenExpirationTime;
+
+    @Builder
+    public LoginInfo(Long memberId, String nickname, String profileImage, String accessToken, String refreshToken, Long refreshTokenExpirationTime) {
+        this.memberId = memberId;
+        this.nickname = nickname;
+        this.profileImage = profileImage;
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.refreshTokenExpirationTime = refreshTokenExpirationTime;
+    }
+
+    public static LoginInfo from(Member member, TokenPair tokenPair) {
+        return LoginInfo.builder()
+                .memberId(member.getId())
+                .nickname(member.getNickname())
+                .profileImage(member.getImageUrl())
+                .accessToken(tokenPair.getAccessToken())
+                .refreshToken(tokenPair.getRefreshToken())
+                .refreshTokenExpirationTime(tokenPair.getRefreshTokenExpirationTime())
+                .build();
+    }
+}

--- a/src/main/java/weavers/siltarae/login/domain/TokenPair.java
+++ b/src/main/java/weavers/siltarae/login/domain/TokenPair.java
@@ -1,4 +1,4 @@
-package weavers.siltarae.login.dto.response;
+package weavers.siltarae.login.domain;
 
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/src/main/java/weavers/siltarae/login/dto/response/LoginResponse.java
+++ b/src/main/java/weavers/siltarae/login/dto/response/LoginResponse.java
@@ -1,0 +1,33 @@
+package weavers.siltarae.login.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import weavers.siltarae.login.domain.LoginInfo;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LoginResponse {
+    private Long memberId;
+    private String nickname;
+    private String profileImage;
+    private String accessToken;
+
+    @Builder
+    public LoginResponse(Long memberId, String nickname, String profileImage, String accessToken) {
+        this.memberId = memberId;
+        this.nickname = nickname;
+        this.profileImage = profileImage;
+        this.accessToken = accessToken;
+    }
+
+    public static LoginResponse from (LoginInfo loginInfo) {
+        return LoginResponse.builder()
+                .memberId(loginInfo.getMemberId())
+                .nickname(loginInfo.getNickname())
+                .profileImage(loginInfo.getProfileImage())
+                .accessToken(loginInfo.getAccessToken())
+                .build();
+    }
+}

--- a/src/main/java/weavers/siltarae/login/infrastructure/GoogleAuthClient.java
+++ b/src/main/java/weavers/siltarae/login/infrastructure/GoogleAuthClient.java
@@ -1,4 +1,4 @@
-package weavers.siltarae.login.domain;
+package weavers.siltarae.login.infrastructure;
 
 import feign.Headers;
 import org.springframework.cloud.openfeign.FeignClient;

--- a/src/main/java/weavers/siltarae/login/infrastructure/GoogleProvider.java
+++ b/src/main/java/weavers/siltarae/login/infrastructure/GoogleProvider.java
@@ -1,4 +1,4 @@
-package weavers.siltarae.login.domain;
+package weavers.siltarae.login.infrastructure;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/weavers/siltarae/login/infrastructure/OAuthProvider.java
+++ b/src/main/java/weavers/siltarae/login/infrastructure/OAuthProvider.java
@@ -1,4 +1,4 @@
-package weavers.siltarae.login.domain;
+package weavers.siltarae.login.infrastructure;
 
 import weavers.siltarae.login.dto.response.MemberInfoResponse;
 

--- a/src/main/java/weavers/siltarae/login/infrastructure/TokenProvider.java
+++ b/src/main/java/weavers/siltarae/login/infrastructure/TokenProvider.java
@@ -1,4 +1,4 @@
-package weavers.siltarae.login.domain;
+package weavers.siltarae.login.infrastructure;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -8,8 +8,9 @@ import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import weavers.siltarae.global.exception.*;
+import weavers.siltarae.login.domain.RefreshToken;
 import weavers.siltarae.login.domain.repository.RefreshTokenRepository;
-import weavers.siltarae.login.dto.response.TokenPair;
+import weavers.siltarae.login.domain.TokenPair;
 
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;

--- a/src/main/java/weavers/siltarae/login/service/LoginService.java
+++ b/src/main/java/weavers/siltarae/login/service/LoginService.java
@@ -6,12 +6,12 @@ import org.springframework.transaction.annotation.Transactional;
 import weavers.siltarae.global.exception.AuthException;
 import weavers.siltarae.global.exception.ExceptionCode;
 import weavers.siltarae.login.AccessTokenExtractor;
-import weavers.siltarae.login.domain.GoogleProvider;
+import weavers.siltarae.login.infrastructure.GoogleProvider;
 import weavers.siltarae.login.domain.LoginInfo;
-import weavers.siltarae.login.domain.TokenProvider;
+import weavers.siltarae.login.infrastructure.TokenProvider;
 import weavers.siltarae.login.dto.response.AccessTokenResponse;
 import weavers.siltarae.login.dto.response.MemberInfoResponse;
-import weavers.siltarae.login.dto.response.TokenPair;
+import weavers.siltarae.login.domain.TokenPair;
 import weavers.siltarae.member.domain.Member;
 import weavers.siltarae.member.domain.repository.MemberRepository;
 

--- a/src/main/java/weavers/siltarae/login/service/LoginService.java
+++ b/src/main/java/weavers/siltarae/login/service/LoginService.java
@@ -7,10 +7,11 @@ import weavers.siltarae.global.exception.AuthException;
 import weavers.siltarae.global.exception.ExceptionCode;
 import weavers.siltarae.login.AccessTokenExtractor;
 import weavers.siltarae.login.domain.GoogleProvider;
+import weavers.siltarae.login.domain.LoginInfo;
 import weavers.siltarae.login.domain.TokenProvider;
 import weavers.siltarae.login.dto.response.AccessTokenResponse;
-import weavers.siltarae.login.dto.response.TokenPair;
 import weavers.siltarae.login.dto.response.MemberInfoResponse;
+import weavers.siltarae.login.dto.response.TokenPair;
 import weavers.siltarae.member.domain.Member;
 import weavers.siltarae.member.domain.repository.MemberRepository;
 
@@ -24,14 +25,16 @@ public class LoginService {
     private final TokenProvider tokenProvider;
     private final GoogleProvider googleProvider;
 
-    public TokenPair login(String code, String redirectUri) {
+    public LoginInfo login(String code, String redirectUri) {
         String authAccessToken = googleProvider.requestAccessToken(code, redirectUri);
         MemberInfoResponse memberInfo = googleProvider.getMemberInfo(authAccessToken);
 
         Member member = memberRepository.findByIdentifier(memberInfo.getIdentifier())
                 .orElseGet(() -> createMember(memberInfo));
 
-        return tokenProvider.createTokenPair(member.getId());
+        TokenPair tokenPair = tokenProvider.createTokenPair(member.getId());
+
+        return LoginInfo.from(member, tokenPair);
     }
 
     public AccessTokenResponse renewAccessToken(String authorizationHeader, String refreshToken) {

--- a/src/main/java/weavers/siltarae/member/service/MemberService.java
+++ b/src/main/java/weavers/siltarae/member/service/MemberService.java
@@ -8,7 +8,7 @@ import org.springframework.web.multipart.MultipartFile;
 import weavers.siltarae.global.exception.BadRequestException;
 import weavers.siltarae.global.image.ImageUtil;
 import weavers.siltarae.global.image.domain.Image;
-import weavers.siltarae.login.domain.TokenProvider;
+import weavers.siltarae.login.infrastructure.TokenProvider;
 import weavers.siltarae.member.domain.Member;
 import weavers.siltarae.member.domain.repository.MemberRepository;
 import weavers.siltarae.member.dto.response.MemberImageResponse;

--- a/src/test/java/weavers/siltarae/global/ControllerTest.java
+++ b/src/test/java/weavers/siltarae/global/ControllerTest.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.ModelAndViewContainer;
 import weavers.siltarae.login.AuthArgumentResolver;
-import weavers.siltarae.login.domain.TokenProvider;
+import weavers.siltarae.login.infrastructure.TokenProvider;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;

--- a/src/test/java/weavers/siltarae/integration/BaseIntegrationTest.java
+++ b/src/test/java/weavers/siltarae/integration/BaseIntegrationTest.java
@@ -6,8 +6,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.transaction.annotation.Transactional;
-import weavers.siltarae.login.domain.TokenProvider;
-import weavers.siltarae.login.dto.response.TokenPair;
+import weavers.siltarae.login.infrastructure.TokenProvider;
+import weavers.siltarae.login.domain.TokenPair;
 import weavers.siltarae.member.domain.Member;
 import weavers.siltarae.member.domain.repository.MemberRepository;
 


### PR DESCRIPTION
## 🔥 관련 이슈
close #194 

## ✨ 변경사항
- 기존에는 로그인 성공 시, 액세스 토큰과 리프레시 토큰만 응답했어요.
- 로그인 성공 시, 토큰 값들과 회원 정보(회원 id, 닉네임, 프로필 이미지)를 함께 반환하도록 수정했어요. 
  - LoginInfo: 토큰 정보와 회원 정보를 함께 담아 컨트롤러에게 전달하는 클래스
  - LoginResponse: 토큰 정보와 회원 정보를 클라이언트 측에 전달하는 DTO
- GoogleProvider, TokenProvider 등 소셜 로그인 관련 제공자들의 패키지를 분리했어요.

## 👀 리뷰 포인트
- 로그인 성공 시 응답에 토큰 정보와 회원 정보를 함께 반환하는 것 vs 로그인 성공 후 별도로 회원 정보를 조회하는 것. 둘 중에 어떤게 더 나을까 고민이 돼요. 후자는 프론트에서 로그인 시 API를 2번 보내는 방식이라 지금은 일단 1번을 선택했어요.
- 중간에 LoginInfo 클래스가 생성되면서 구조가 조금 복잡해졌는데 괜찮을까요?
  - LoginService는 `TokenProvider로부터 받아온 토큰 값` + `MemberRepository로 조회한 회원 정보`를 LoginInfo 객체에 담아 LoginController로 전달해요.
  - 그럼 컨트롤러는 다시 LoginInfo에 담긴 값들을 빼내서 쿠키를 설정하고, 응답 body에 필요한 값을 넣어주는 방식이에요.
- 패키지 구조가 이게 최선일까? 싶은 생각이 들어요. `login.infrastructure` 패키지에 다양한 Provider들을 넣고, `login.domain`에는 내부에서 사용하는 데이터 전달용 클래스들만 남겨두었는데... `login.infrastructre.google`처럼 패키지를 조금 더 세분화할지, 아니면 이대로도 괜찮을지 고민돼요.

## 📝 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
