### PR TITLE
fix: [#197] 로그아웃 시 리프레시 토큰 쿠키 삭제 로직 추가

### DIFF
--- a/src/main/java/weavers/siltarae/login/controller/LoginController.java
+++ b/src/main/java/weavers/siltarae/login/controller/LoginController.java
@@ -23,13 +23,15 @@ public class LoginController {
 
     private final LoginService loginService;
 
+    private final String REFRESH_TOKEN = "refresh-token";
+
     @PostMapping("/login/{socialType}")
     public ResponseEntity<LoginResponse> login(@PathVariable final String socialType,
                                                @RequestBody final LoginRequest request) {
 
         LoginInfo loginInfo = loginService.login(request.getAuthCode(), request.getRedirectUri());
 
-        ResponseCookie cookie = ResponseCookie.from("refresh-token", loginInfo.getRefreshToken())
+        ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN, loginInfo.getRefreshToken())
                 .maxAge(loginInfo.getRefreshTokenExpirationTime())
                 .sameSite("None")
                 .secure(true)
@@ -61,7 +63,14 @@ public class LoginController {
             @CookieValue("refresh-token") final String refreshToken) {
         loginService.logout(refreshToken);
 
-        return ResponseEntity.noContent().build();
+        ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN, null)
+                .maxAge(0)
+                .path("/")
+                .build();
+
+        return ResponseEntity.noContent()
+                .header(SET_COOKIE, cookie.toString())
+                .build();
     }
 
 }


### PR DESCRIPTION
## 🔥 관련 이슈
close #197 

## ✨ 변경사항
- 로그아웃 시 리프레시 토큰 쿠키를 삭제하는 로직을 추가했어요.

## 📝 작업 유형
- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
