### PR TITLE
fix: [#199] 태그명 중복 검사 조건 수정

### DIFF
--- a/src/main/java/weavers/siltarae/tag/domain/repository/TagRepository.java
+++ b/src/main/java/weavers/siltarae/tag/domain/repository/TagRepository.java
@@ -6,7 +6,7 @@ import weavers.siltarae.tag.domain.Tag;
 import java.util.List;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
-    boolean existsByMember_IdAndName(Long memberId, String name);
+    boolean existsByMember_IdAndNameAndDeletedAtIsNull(Long memberId, String name);
 
     List<Tag> findAllByMember_IdAndDeletedAtIsNull(Long userId);
 

--- a/src/main/java/weavers/siltarae/tag/service/TagService.java
+++ b/src/main/java/weavers/siltarae/tag/service/TagService.java
@@ -71,7 +71,7 @@ public class TagService {
     }
 
     private boolean checkDuplicateTagName(final Long memberId, final String tagName) {
-        return tagRepository.existsByMember_IdAndName(memberId, tagName);
+        return tagRepository.existsByMember_IdAndNameAndDeletedAtIsNull(memberId, tagName);
     }
 
     private boolean hasDeletedTag(List<Tag> tagList) {

--- a/src/test/java/weavers/siltarae/tag/service/TagServiceTest.java
+++ b/src/test/java/weavers/siltarae/tag/service/TagServiceTest.java
@@ -56,7 +56,7 @@ class TagServiceTest {
         TagCreateRequest request = new TagCreateRequest("회사");
         given(memberRepository.findById(anyLong()))
                 .willReturn(Optional.ofNullable(USER_KIM()));
-        given(tagRepository.existsByMember_IdAndName(1L, "회사"))
+        given(tagRepository.existsByMember_IdAndNameAndDeletedAtIsNull(1L, "회사"))
                 .willReturn(true);
 
         // when


### PR DESCRIPTION
## 🔥 관련 이슈
close #199 

## ✨ 변경사항
- 태그명 중복 검사 시, 삭제된 태그는 중복 검사 대상에서 제외했어요.
- 이제 삭제된 태그와 겹치는 이름의 새로운 태그를 개설할 수 있어요!

## 📝 작업 유형
- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
