### PR TITLE
fix: 댓글 등록 Response 에 memberImageUrl 추가

### DIFF
--- a/src/main/java/weavers/siltarae/comment/service/CommentService.java
+++ b/src/main/java/weavers/siltarae/comment/service/CommentService.java
@@ -42,12 +42,7 @@ public class CommentService {
                         .build()
         );
 
-        return CommentResponse.builder()
-                .commentId(comment.getId())
-                .commentContent(comment.getContent())
-                .memberId(comment.getMember().getId())
-                .memberName(comment.getMember().getNickname())
-                .build();
+        return CommentResponse.from(comment);
     }
 
     public void delete(Long commentId, Long memberId) {


### PR DESCRIPTION
## 🔥 관련 이슈
Issue:  #201 

## ✨ 변경사항
- 댓글 등록 Response 에 memberImageUrl 값을 추가했습니다.

## 📝 작업 유형
- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
